### PR TITLE
Create admin landing dashboard

### DIFF
--- a/apps/server/src/app/page.tsx
+++ b/apps/server/src/app/page.tsx
@@ -1,107 +1,265 @@
-import Image from "next/image";
+"use client";
+
 import Link from "next/link";
-import { AccountSettingsCards, AccountView } from "@daveyplate/better-auth-ui";
+import {
+  BarChart3,
+  CalendarDays,
+  LayoutDashboard,
+  MessageSquare,
+  Settings,
+  ShieldCheck,
+  Users,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator } from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarSeparator,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
+
+const navigation = [
+  {
+    label: "Workspace",
+    items: [
+      {
+        title: "Dashboard",
+        href: "/",
+        icon: LayoutDashboard,
+      },
+      {
+        title: "Calendar",
+        href: "#calendar",
+        icon: CalendarDays,
+      },
+      {
+        title: "Messages",
+        href: "#messages",
+        icon: MessageSquare,
+      },
+    ],
+  },
+  {
+    label: "Management",
+    items: [
+      {
+        title: "Users",
+        href: "#users",
+        icon: Users,
+      },
+      {
+        title: "Security",
+        href: "#security",
+        icon: ShieldCheck,
+      },
+      {
+        title: "Reports",
+        href: "#reports",
+        icon: BarChart3,
+      },
+      {
+        title: "Settings",
+        href: "#settings",
+        icon: Settings,
+      },
+    ],
+  },
+];
+
+const highlights = [
+  {
+    title: "Instant access",
+    description:
+      "Connect Better Auth and sign in with a single click using the secure hosted flow.",
+  },
+  {
+    title: "Team visibility",
+    description:
+      "Invite teammates, manage roles, and keep your workspace in sync in seconds.",
+  },
+  {
+    title: "Real-time insights",
+    description:
+      "Track adoption and engagement with actionable analytics surfaced in real time.",
+  },
+];
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Link href={"/auth/sign-in"}>Sign in</Link>
-        <AccountView />
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+    <SidebarProvider>
+      <div className="bg-muted/30 flex min-h-screen w-full">
+        <Sidebar>
+          <SidebarHeader className="gap-3">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                calendar sync
+              </p>
+              <p className="text-lg font-semibold text-sidebar-foreground">
+                Admin Console
+              </p>
+            </div>
+          </SidebarHeader>
+          <SidebarSeparator />
+          <SidebarContent>
+            {navigation.map((group) => (
+              <SidebarGroup key={group.label}>
+                <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    {group.items.map((item) => (
+                      <SidebarMenuItem key={item.title}>
+                        <SidebarMenuButton asChild isActive={item.href === "/"}>
+                          <Link href={item.href} className="flex items-center gap-2">
+                            <item.icon className="size-4" />
+                            <span>{item.title}</span>
+                          </Link>
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    ))}
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </SidebarGroup>
+            ))}
+          </SidebarContent>
+          <SidebarFooter>
+            <div className="rounded-lg border border-dashed p-3 text-xs text-sidebar-foreground/80">
+              Secure authentication powered by Better Auth.
+            </div>
+          </SidebarFooter>
+        </Sidebar>
+        <SidebarInset>
+          <header className="border-b bg-background/80 sticky top-0 z-10 flex h-16 items-center gap-4 px-6 backdrop-blur">
+            <SidebarTrigger className="md:hidden" />
+            <div className="flex flex-1 items-center justify-between gap-4">
+              <Breadcrumb>
+                <BreadcrumbList>
+                  <BreadcrumbItem>
+                    <BreadcrumbLink asChild>
+                      <Link href="/">Admin</Link>
+                    </BreadcrumbLink>
+                  </BreadcrumbItem>
+                  <BreadcrumbSeparator />
+                  <BreadcrumbItem>
+                    <BreadcrumbPage>Overview</BreadcrumbPage>
+                  </BreadcrumbItem>
+                </BreadcrumbList>
+              </Breadcrumb>
+              <Button asChild variant="default" size="sm">
+                <Link href="/auth/sign-in">Sign in</Link>
+              </Button>
+            </div>
+          </header>
+          <div className="flex flex-1 flex-col gap-8 px-6 py-10">
+            <section className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+              <Card className="bg-gradient-to-br from-primary/15 via-background to-background">
+                <CardHeader>
+                  <Badge variant="secondary" className="w-fit text-xs uppercase">
+                    Powered by Better Auth
+                  </Badge>
+                  <CardTitle className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+                    Welcome to your calendar operations hub
+                  </CardTitle>
+                  <CardDescription className="max-w-xl text-base text-muted-foreground">
+                    Manage users, monitor integrations, and keep every event in sync across your organization with a single secure
+                    dashboard.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="flex flex-wrap items-center gap-4">
+                  <Button asChild size="lg">
+                    <Link href="/auth/sign-in" className="font-semibold">
+                      Launch the console
+                    </Link>
+                  </Button>
+                  <Button asChild variant="outline" size="lg">
+                    <Link href="#highlights">Explore features</Link>
+                  </Button>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-2xl">Live workspace status</CardTitle>
+                  <CardDescription>
+                    Authentication and synchronization events refresh automatically through tRPC powered subscriptions.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="grid gap-4">
+                  <div className="flex items-center justify-between rounded-lg border bg-muted/40 px-4 py-3">
+                    <span className="text-sm text-muted-foreground">Active connections</span>
+                    <span className="text-2xl font-semibold text-foreground">28</span>
+                  </div>
+                  <div className="flex items-center justify-between rounded-lg border bg-muted/40 px-4 py-3">
+                    <span className="text-sm text-muted-foreground">Verified organizations</span>
+                    <span className="text-2xl font-semibold text-foreground">12</span>
+                  </div>
+                  <div className="flex items-center justify-between rounded-lg border bg-muted/40 px-4 py-3">
+                    <span className="text-sm text-muted-foreground">Sync success rate</span>
+                    <span className="text-2xl font-semibold text-foreground">99.2%</span>
+                  </div>
+                </CardContent>
+              </Card>
+            </section>
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+            <section id="highlights" className="grid gap-6 lg:grid-cols-3">
+              {highlights.map((highlight) => (
+                <Card key={highlight.title}>
+                  <CardHeader>
+                    <CardTitle className="text-xl font-semibold">
+                      {highlight.title}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-sm text-muted-foreground">{highlight.description}</p>
+                  </CardContent>
+                </Card>
+              ))}
+            </section>
+
+            <section className="grid gap-4 rounded-xl border bg-card/60 p-6">
+              <div>
+                <h2 className="text-2xl font-semibold tracking-tight">Ready when you are</h2>
+                <p className="text-sm text-muted-foreground">
+                  Sign in to access the complete admin dashboard, manage accounts, and trigger secure calendar synchronizations.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-3">
+                <Button asChild>
+                  <Link href="/auth/sign-in">
+                    Sign in to continue
+                  </Link>
+                </Button>
+                <Button asChild variant="ghost">
+                  <Link href="mailto:team@calendarsync.app">Contact support</Link>
+                </Button>
+              </div>
+            </section>
+          </div>
+        </SidebarInset>
+      </div>
+    </SidebarProvider>
   );
 }


### PR DESCRIPTION
## Summary
- build a new landing experience that wraps the home page in the shadcn sidebar layout with breadcrumb navigation
- add hero, metrics, and feature highlight sections that promote the Better Auth powered console and provide sign-in CTAs

## Testing
- bun run build *(fails: unable to download Geist fonts in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ca8bb312108327994044ae93b413dc