### PR TITLE
Add Providers link to admin navigation

### DIFF
--- a/apps/server/src/config/ui.ts
+++ b/apps/server/src/config/ui.ts
@@ -3,6 +3,7 @@ import {
 	CalendarDays,
 	LayoutDashboard,
 	MessageSquare,
+	Network,
 	Settings,
 	ShieldCheck,
 	Users,
@@ -19,9 +20,10 @@ export const defaultNavigation: NavGroup[] = [
 		],
 	},
 	{
-		label: "Management",
+		label: "Admin",
 		items: [
 			{ title: "Users", href: "#users", icon: Users },
+			{ title: "Providers", href: "/admin/providers", icon: Network },
 			{ title: "Security", href: "#security", icon: ShieldCheck },
 			{ title: "Reports", href: "#reports", icon: BarChart3 },
 			{ title: "Settings", href: "#settings", icon: Settings },


### PR DESCRIPTION
## Summary
- add a Providers entry to the admin navigation menu
- update the management group label to "Admin" to match naming conventions

## Testing
- bunx biome check apps/server/src/config/ui.ts

------
https://chatgpt.com/codex/tasks/task_b_68cc1d084a208327a317238ca6301bbd