### PR TITLE
feat: manage organization providers with multi-select

### DIFF
--- a/apps/server/src/components/admin/CalendarProvidersCard.tsx
+++ b/apps/server/src/components/admin/CalendarProvidersCard.tsx
@@ -1,117 +1,192 @@
 "use client";
 
+import * as React from "react";
+import type { CheckedState } from "@radix-ui/react-checkbox";
 import { AlertCircle } from "lucide-react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+        Card,
+        CardContent,
+        CardDescription,
+        CardHeader,
+        CardTitle,
+} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useProviderList } from "@/hooks/use-provider-admin";
+import { useLinkOrgProviders, useOrgProviderList } from "@/hooks/use-provider-admin";
 
 type ProviderOption = {
-	id: string;
-	name: string;
-	description?: string | null;
+        id: string;
+        name: string;
+        description: string | null;
+        linked: boolean;
 };
 
-function normaliseProvider(option: unknown): ProviderOption | null {
-	if (typeof option === "string") {
-		return { id: option, name: option };
-	}
-
-	if (!option || typeof option !== "object") {
-		return null;
-	}
-
-	const record = option as Record<string, unknown>;
-	const rawId = record.id ?? record.providerId ?? record.slug;
-	const id = typeof rawId === "string" ? rawId : rawId ? String(rawId) : null;
-
-	if (!id) {
-		return null;
-	}
-
-	const nameSource =
-		record.name ?? record.label ?? record.title ?? record.providerName ?? id;
-	const name =
-		typeof nameSource === "string" ? nameSource : String(nameSource ?? id);
-
-	const descriptionSource =
-		record.description ?? record.summary ?? record.details ?? null;
-
-	return {
-		id,
-		name,
-		description:
-			typeof descriptionSource === "string" ? descriptionSource : null,
-	};
-}
-
 export type CalendarProvidersCardProps = {
-	slug: string;
+        slug: string;
 };
 
 export function CalendarProvidersCard({ slug }: CalendarProvidersCardProps) {
-	const providersQuery = useProviderList(slug, { limit: 100 });
+        const providersQuery = useOrgProviderList(slug);
+        const linkMutation = useLinkOrgProviders(slug);
 
-	const options = (providersQuery.data?.items ?? [])
-		.map((option) => normaliseProvider(option))
-		.filter((option): option is ProviderOption => Boolean(option));
+        const items: ProviderOption[] = providersQuery.data?.items ?? [];
 
-	return (
-		<Card>
-			<CardHeader>
-				<CardTitle>Calendar providers</CardTitle>
-			</CardHeader>
-			<CardContent className="grid gap-4">
-				{providersQuery.isError ? (
-					<Alert variant="destructive">
-						<AlertCircle className="mt-0.5" />
-						<AlertTitle>Unable to load providers</AlertTitle>
-						<AlertDescription>
-							{(providersQuery.error as Error)?.message ??
-								"Something went wrong while fetching providers."}
-						</AlertDescription>
-					</Alert>
-				) : providersQuery.isLoading ? (
-					<div className="space-y-3">
-						{[0, 1, 2].map((item) => (
-							<div key={item} className="flex items-center gap-3">
-								<Skeleton className="size-4 rounded" />
-								<div className="flex-1 space-y-1">
-									<Skeleton className="h-3 w-32" />
-									<Skeleton className="h-3 w-48" />
-								</div>
-							</div>
-						))}
-					</div>
-				) : options.length === 0 ? (
-					<Alert>
-						<AlertTitle>No providers available</AlertTitle>
-						<AlertDescription>
-							Configure providers from the organization settings to make them
-							available here.
-						</AlertDescription>
-					</Alert>
-				) : (
-					<div className="space-y-3">
-						{options.map((option) => (
-							<div
-								key={option.id}
-								className="rounded-lg border border-border p-3"
-							>
-								<p className="font-medium text-foreground text-sm">
-									{option.name}
-								</p>
-								{option.description ? (
-									<p className="text-muted-foreground text-sm">
-										{option.description}
-									</p>
-								) : null}
-							</div>
-						))}
-					</div>
-				)}
-			</CardContent>
-		</Card>
-	);
+        const initialSelection = React.useMemo(
+                () => items.filter((item) => item.linked).map((item) => item.id),
+                [items],
+        );
+
+        const [selected, setSelected] = React.useState<string[]>([]);
+
+        React.useEffect(() => {
+                setSelected(initialSelection);
+        }, [initialSelection]);
+
+        const initialSet = React.useMemo(() => new Set(initialSelection), [initialSelection]);
+        const selectedSet = React.useMemo(() => new Set(selected), [selected]);
+
+        const hasChanges = React.useMemo(() => {
+                if (initialSet.size !== selectedSet.size) {
+                        return true;
+                }
+
+                for (const id of selectedSet) {
+                        if (!initialSet.has(id)) {
+                                return true;
+                        }
+                }
+
+                return false;
+        }, [initialSet, selectedSet]);
+
+        const toggleSelection = React.useCallback(
+                (id: string, checked: CheckedState) => {
+                        if (linkMutation.isPending) {
+                                return;
+                        }
+
+                        setSelected((previous) => {
+                                const next = new Set(previous);
+
+                                if (checked === true) {
+                                        next.add(id);
+                                } else {
+                                        next.delete(id);
+                                }
+
+                                return Array.from(next);
+                        });
+                },
+                [linkMutation.isPending],
+        );
+
+        const handleSave = React.useCallback(() => {
+                if (!hasChanges) {
+                        return;
+                }
+
+                linkMutation.mutate({ providerIds: selected });
+        }, [hasChanges, linkMutation, selected]);
+
+        const handleReset = React.useCallback(() => {
+                setSelected(Array.from(initialSet));
+        }, [initialSet]);
+
+        return (
+                <Card>
+                        <CardHeader>
+                                <CardTitle>Calendar providers</CardTitle>
+                                <CardDescription>
+                                        Choose which providers are available to this organization.
+                                </CardDescription>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                                {providersQuery.isError ? (
+                                        <Alert variant="destructive">
+                                                <AlertCircle className="mt-0.5" />
+                                                <AlertTitle>Unable to load providers</AlertTitle>
+                                                <AlertDescription>
+                                                        {providersQuery.error instanceof Error
+                                                                ? providersQuery.error.message
+                                                                : "Something went wrong while fetching providers."}
+                                                </AlertDescription>
+                                        </Alert>
+                                ) : providersQuery.isLoading ? (
+                                        <div className="space-y-3">
+                                                {[0, 1, 2].map((item) => (
+                                                        <div key={item} className="flex items-center gap-3">
+                                                                <Skeleton className="size-4 rounded" />
+                                                                <div className="flex-1 space-y-1">
+                                                                        <Skeleton className="h-3 w-32" />
+                                                                        <Skeleton className="h-3 w-48" />
+                                                                </div>
+                                                        </div>
+                                                ))}
+                                        </div>
+                                ) : items.length === 0 ? (
+                                        <Alert>
+                                                <AlertTitle>No providers available</AlertTitle>
+                                                <AlertDescription>
+                                                        Configure providers from the organization settings to make them
+                                                        available here.
+                                                </AlertDescription>
+                                        </Alert>
+                                ) : (
+                                        <>
+                                                <div className="space-y-3">
+                                                        {items.map((item) => {
+                                                                const inputId = `provider-${item.id}`;
+
+                                                                return (
+                                                                        <label
+                                                                                key={item.id}
+                                                                                htmlFor={inputId}
+                                                                                className="flex items-start gap-3 rounded-lg border border-border p-3"
+                                                                        >
+                                                                                <Checkbox
+                                                                                        id={inputId}
+                                                                                        checked={selectedSet.has(item.id)}
+                                                                                        onCheckedChange={(checked) =>
+                                                                                                toggleSelection(item.id, checked)
+                                                                                        }
+                                                                                        disabled={linkMutation.isPending}
+                                                                                />
+                                                                                <div className="space-y-1">
+                                                                                        <p className="text-sm font-medium text-foreground">
+                                                                                                {item.name}
+                                                                                        </p>
+                                                                                        {item.description ? (
+                                                                                                <p className="text-sm text-muted-foreground">
+                                                                                                        {item.description}
+                                                                                                </p>
+                                                                                        ) : null}
+                                                                                </div>
+                                                                        </label>
+                                                                );
+                                                        })}
+                                                </div>
+                                                <div className="flex justify-end gap-2">
+                                                        <Button
+                                                                variant="outline"
+                                                                onClick={handleReset}
+                                                                disabled={!hasChanges || linkMutation.isPending}
+                                                        >
+                                                                Discard changes
+                                                        </Button>
+                                                        <Button
+                                                                onClick={handleSave}
+                                                                disabled={!hasChanges || linkMutation.isPending}
+                                                                aria-busy={linkMutation.isPending}
+                                                        >
+                                                                Save changes
+                                                        </Button>
+                                                </div>
+                                        </>
+                                )}
+                        </CardContent>
+                </Card>
+        );
 }

--- a/apps/server/src/hooks/use-provider-admin.ts
+++ b/apps/server/src/hooks/use-provider-admin.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
+import { toast } from "sonner";
 
 import { providerKeys } from "@/lib/query-keys/providers";
 import { trpcClient } from "@/lib/trpc-client";
@@ -10,65 +11,35 @@ import type { AppRouter } from "@/routers";
 type ProvidersRouterInputs = inferRouterInputs<AppRouter>["providers"];
 type ProvidersRouterOutputs = inferRouterOutputs<AppRouter>["providers"];
 
-type ListParams = Omit<ProvidersRouterInputs["list"], "slug">;
-type ListResponse = ProvidersRouterOutputs["list"];
+type OrgListResponse = ProvidersRouterOutputs["org"]["list"];
 
-type ProviderDetailResponse = ProvidersRouterOutputs["get"];
+type LinkVariables = Omit<ProvidersRouterInputs["org"]["link"], "slug">;
+type LinkResponse = ProvidersRouterOutputs["org"]["link"];
 
-type SaveVariables = Omit<ProvidersRouterInputs["save"], "slug">;
-type SaveResponse = ProvidersRouterOutputs["save"];
-
-type TestVariables = Omit<ProvidersRouterInputs["test"], "slug">;
-type TestResponse = ProvidersRouterOutputs["test"];
-
-export function useProviderList(slug: string, params?: ListParams) {
-	return useQuery<ListResponse>({
-		queryKey: providerKeys.list(slug, params),
-		queryFn: () => trpcClient.providers.list.query({ slug, ...(params ?? {}) }),
-		enabled: Boolean(slug),
-	});
+export function useOrgProviderList(slug: string) {
+        return useQuery<OrgListResponse>({
+                queryKey: providerKeys.orgList(slug),
+                queryFn: () => trpcClient.providers.org.list.query({ slug }),
+                enabled: Boolean(slug),
+        });
 }
 
-export function useProviderDraft(slug: string, providerId: string) {
-	return useQuery<ProviderDetailResponse>({
-		queryKey: providerKeys.detail(slug, providerId),
-		queryFn: () => trpcClient.providers.get.query({ slug, providerId }),
-		enabled: Boolean(slug && providerId),
-	});
-}
+export function useLinkOrgProviders(slug: string) {
+        const queryClient = useQueryClient();
 
-export function useSaveProvider(slug: string) {
-	const queryClient = useQueryClient();
+        return useMutation<LinkResponse, Error, LinkVariables>({
+                mutationFn: (variables) =>
+                        trpcClient.providers.org.link.mutate({ slug, ...variables }),
+                onSuccess: async () => {
+                        toast.success("Updated provider availability");
 
-	return useMutation<SaveResponse, Error, SaveVariables>({
-		mutationFn: (variables) =>
-			trpcClient.providers.save.mutate({ slug, ...variables }),
-		onSuccess: (result) => {
-			queryClient.invalidateQueries({ queryKey: providerKeys.listRoot(slug) });
-
-			if (result?.providerId) {
-				queryClient.invalidateQueries({
-					queryKey: providerKeys.detail(slug, result.providerId),
-				});
-			}
-		},
-	});
-}
-
-export function useTestProvider(slug: string) {
-	const queryClient = useQueryClient();
-
-	return useMutation<TestResponse, Error, TestVariables>({
-		mutationFn: (variables) =>
-			trpcClient.providers.test.mutate({ slug, ...variables }),
-		onSuccess: (result) => {
-			queryClient.invalidateQueries({ queryKey: providerKeys.listRoot(slug) });
-
-			if (result?.providerId) {
-				queryClient.invalidateQueries({
-					queryKey: providerKeys.detail(slug, result.providerId),
-				});
-			}
-		},
-	});
+                        await Promise.all([
+                                queryClient.invalidateQueries({ queryKey: providerKeys.orgRoot(slug) }),
+                                queryClient.invalidateQueries({ queryKey: providerKeys.listRoot(slug) }),
+                        ]);
+                },
+                onError: (error) => {
+                        toast.error(error.message ?? "Unable to update providers");
+                },
+        });
 }

--- a/apps/server/src/lib/query-keys/providers.ts
+++ b/apps/server/src/lib/query-keys/providers.ts
@@ -1,6 +1,8 @@
 export const providerKeys = {
-	all: ["providers"] as const,
-	listRoot: (slug: string) => [...providerKeys.all, slug, "list"] as const,
+        all: ["providers"] as const,
+        orgRoot: (slug: string) => [...providerKeys.all, "org", slug] as const,
+        orgList: (slug: string) => [...providerKeys.orgRoot(slug), "list"] as const,
+        listRoot: (slug: string) => [...providerKeys.all, slug, "list"] as const,
 	list: (
 		slug: string,
 		params?: {


### PR DESCRIPTION
## Summary
- replace the calendar providers card with a client multi-select that saves org provider links
- add hooks and query keys that target the new providers.org procedures
- expose providers.org.list and providers.org.link on the tRPC router for fetching and persisting selections

## Testing
- ⚠️ `bunx tsc --noEmit` *(fails due to existing type errors in providers admin pages and nodemailer typings)*

------
https://chatgpt.com/codex/tasks/task_b_68cc4c33a3c48327a59e18cc9764d2e0