### PR TITLE
Use select for provider category

### DIFF
--- a/apps/server/src/app/(site)/admin/providers/[providerId]/page.tsx
+++ b/apps/server/src/app/(site)/admin/providers/[providerId]/page.tsx
@@ -37,6 +37,10 @@ import {
 } from "@/hooks/use-provider-admin";
 
 const providerStatuses = ["draft", "beta", "active", "deprecated"] as const;
+const providerCategories = [
+  { label: "Email", value: "email" },
+  { label: "Google", value: "google" },
+] as const;
 
 type ProviderFormValues = {
   id?: string;
@@ -300,9 +304,20 @@ export default function ProviderDetailPage() {
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>Category</FormLabel>
-                        <FormControl>
-                          <Input placeholder="email" {...field} />
-                        </FormControl>
+                        <Select value={field.value} onValueChange={field.onChange}>
+                          <FormControl>
+                            <SelectTrigger className="w-full">
+                              <SelectValue placeholder="Select category" />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {providerCategories.map((category) => (
+                              <SelectItem key={category.value} value={category.value}>
+                                {category.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
                         <FormMessage />
                       </FormItem>
                     )}


### PR DESCRIPTION
## Summary
- add provider category metadata for the admin provider form
- render the category field with the shared Select component and map each option

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ccff027278832798b2f05ec63a6ef3