### PR TITLE
feat(admin): add admin users management

### DIFF
--- a/apps/server/src/app/(site)/admin/layout.tsx
+++ b/apps/server/src/app/(site)/admin/layout.tsx
@@ -1,7 +1,32 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
 import React from "react";
 
-const layout = ({ children }: { children: React.ReactNode }) => {
-  return children;
-};
+import { RequireAdmin } from "@/components/admin/RequireAdmin";
+import { auth } from "@/lib/auth";
 
-export default layout;
+export default async function AdminLayout({
+        children,
+}: {
+        children: React.ReactNode;
+}) {
+        const session = await auth.api.getSession({
+                headers: headers(),
+        });
+
+        if (!session) {
+                redirect("/auth/sign-in");
+        }
+
+        const roles = Array.isArray(session.user?.roles)
+                ? session.user.roles
+                : session.user?.role
+                        ? [session.user.role]
+                        : [];
+
+        if (!roles?.includes("admin")) {
+                redirect("/");
+        }
+
+        return <RequireAdmin>{children}</RequireAdmin>;
+}

--- a/apps/server/src/app/(site)/admin/users/page.tsx
+++ b/apps/server/src/app/(site)/admin/users/page.tsx
@@ -1,0 +1,653 @@
+"use client";
+
+import { RedirectToSignIn, UserAvatar } from "@daveyplate/better-auth-ui";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { MoreHorizontal } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import Link from "next/link";
+import * as React from "react";
+import { toast } from "sonner";
+
+import AppShell from "@/components/layout/AppShell";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+        Card,
+        CardContent,
+        CardDescription,
+        CardHeader,
+        CardTitle,
+} from "@/components/ui/card";
+import {
+        DropdownMenu,
+        DropdownMenuCheckboxItem,
+        DropdownMenuContent,
+        DropdownMenuItem,
+        DropdownMenuLabel,
+        DropdownMenuSeparator,
+        DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import {
+        Pagination,
+        PaginationContent,
+        PaginationItem,
+        PaginationLink,
+        PaginationNext,
+        PaginationPrevious,
+} from "@/components/ui/pagination";
+import {
+        Select,
+        SelectContent,
+        SelectItem,
+        SelectTrigger,
+        SelectValue,
+} from "@/components/ui/select";
+import {
+        Table,
+        TableBody,
+        TableCell,
+        TableHead,
+        TableHeader,
+        TableRow,
+} from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { authClient } from "@/lib/auth-client";
+import { trpcClient } from "@/lib/trpc-client";
+
+const statusOptions = [
+        { label: "All statuses", value: "all" },
+        { label: "Active", value: "active" },
+        { label: "Banned", value: "banned" },
+] as const;
+
+type SortField = "createdAt" | "name" | "email";
+type SortDir = "asc" | "desc";
+
+type ListParams = {
+        q?: string;
+        roles?: string[];
+        status?: "active" | "banned" | "all";
+        calendarId?: string;
+        page: number;
+        pageSize: number;
+        sort: { field: SortField; dir: SortDir };
+};
+
+function useDebouncedValue<T>(value: T, delay = 400) {
+        const [debounced, setDebounced] = React.useState(value);
+
+        React.useEffect(() => {
+                const timeout = window.setTimeout(() => setDebounced(value), delay);
+                return () => window.clearTimeout(timeout);
+        }, [value, delay]);
+
+        return debounced;
+}
+
+export default function AdminUsersPage() {
+        const queryClient = useQueryClient();
+        const [search, setSearch] = React.useState("");
+        const [selectedRoles, setSelectedRoles] = React.useState<string[]>([]);
+        const [status, setStatus] = React.useState<(typeof statusOptions)[number]["value"]>("all");
+        const [calendarId, setCalendarId] = React.useState<string | "">("");
+        const [page, setPage] = React.useState(1);
+        const [pageSize, setPageSize] = React.useState(25);
+        const [sort, setSort] = React.useState<{ field: SortField; dir: SortDir }>({
+                field: "createdAt",
+                dir: "desc",
+        });
+        const [resettingUserId, setResettingUserId] = React.useState<string | null>(null);
+
+        const debouncedSearch = useDebouncedValue(search);
+
+        React.useEffect(() => {
+                setPage(1);
+        }, [debouncedSearch, selectedRoles, status, calendarId, pageSize]);
+
+        const listParams = React.useMemo<ListParams>(
+                () => ({
+                        ...(debouncedSearch ? { q: debouncedSearch } : {}),
+                        ...(selectedRoles.length ? { roles: selectedRoles } : {}),
+                        status,
+                        ...(calendarId ? { calendarId } : {}),
+                        page,
+                        pageSize,
+                        sort,
+                }),
+                [calendarId, debouncedSearch, page, pageSize, selectedRoles, sort, status],
+        );
+
+        const listKey = React.useMemo(() => ["adminUsers", "list", listParams] as const, [listParams]);
+
+        const listQuery = useQuery({
+                queryKey: listKey,
+                queryFn: () => trpcClient.adminUsers.list.query(listParams),
+                keepPreviousData: true,
+        });
+
+        const rolesQuery = useQuery({
+                queryKey: ["adminUsers", "rolesOptions"],
+                queryFn: () => trpcClient.adminUsers.rolesOptions.query(),
+        });
+
+        const calendarsQuery = useQuery({
+                queryKey: ["adminUsers", "calendarsOptions"],
+                queryFn: () => trpcClient.adminUsers.calendarsOptions.query(),
+        });
+
+        const banMutation = useMutation({
+                mutationKey: ["adminUsers", "ban"],
+                mutationFn: (input: { userId: string }) => trpcClient.adminUsers.ban.mutate(input),
+                onMutate: async ({ userId }) => {
+                        await queryClient.cancelQueries({ queryKey: listKey });
+                        const previous = queryClient.getQueryData(listKey) as Awaited<typeof listQuery.data> | undefined;
+                        if (previous) {
+                                queryClient.setQueryData(listKey, {
+                                        ...previous,
+                                        items: previous.items.map((item) =>
+                                                item.userId === userId ? { ...item, isBanned: true } : item,
+                                        ),
+                                });
+                        }
+                        return { previous };
+                },
+                onError: (error, _variables, context) => {
+                        if (context?.previous) {
+                                queryClient.setQueryData(listKey, context.previous);
+                        }
+                        toast.error(error instanceof Error ? error.message : "Unable to ban user");
+                },
+                onSuccess: () => {
+                        toast.success("User banned");
+                },
+                onSettled: () => {
+                        queryClient.invalidateQueries({ queryKey: listKey });
+                },
+        });
+
+        const reactivateMutation = useMutation({
+                mutationKey: ["adminUsers", "reactivate"],
+                mutationFn: (input: { userId: string }) => trpcClient.adminUsers.reactivate.mutate(input),
+                onMutate: async ({ userId }) => {
+                        await queryClient.cancelQueries({ queryKey: listKey });
+                        const previous = queryClient.getQueryData(listKey) as Awaited<typeof listQuery.data> | undefined;
+                        if (previous) {
+                                queryClient.setQueryData(listKey, {
+                                        ...previous,
+                                        items: previous.items.map((item) =>
+                                                item.userId === userId ? { ...item, isBanned: false } : item,
+                                        ),
+                                });
+                        }
+                        return { previous };
+                },
+                onError: (error, _variables, context) => {
+                        if (context?.previous) {
+                                queryClient.setQueryData(listKey, context.previous);
+                        }
+                        toast.error(error instanceof Error ? error.message : "Unable to reactivate user");
+                },
+                onSuccess: () => {
+                        toast.success("User reactivated");
+                },
+                onSettled: () => {
+                        queryClient.invalidateQueries({ queryKey: listKey });
+                },
+        });
+
+        const totalPages = listQuery.data ? Math.max(1, Math.ceil(listQuery.data.total / listQuery.data.pageSize)) : 1;
+
+        const handleToggleRole = React.useCallback(
+                (role: string) => {
+                        setSelectedRoles((prev) => {
+                                const next = prev.includes(role)
+                                        ? prev.filter((item) => item !== role)
+                                        : [...prev, role];
+                                return next;
+                        });
+                },
+                [],
+        );
+
+        const handleSort = React.useCallback(
+                (field: SortField) => {
+                        setSort((current) => {
+                                if (current.field !== field) {
+                                        return { field, dir: "asc" };
+                                }
+                                return { field, dir: current.dir === "asc" ? "desc" : "asc" };
+                        });
+                },
+                [],
+        );
+
+        const isLoading = listQuery.isPending;
+        const rows = listQuery.data?.items ?? [];
+        const summaryStart = listQuery.data && listQuery.data.total > 0
+                ? (listQuery.data.page - 1) * listQuery.data.pageSize + 1
+                : 0;
+        const summaryEnd = listQuery.data && listQuery.data.total > 0
+                ? Math.min(listQuery.data.total, listQuery.data.page * listQuery.data.pageSize)
+                : 0;
+
+        const handleSendReset = React.useCallback(
+                async (userId: string, email: string) => {
+                        try {
+                                setResettingUserId(userId);
+                                const redirectTo = typeof window !== "undefined"
+                                        ? `${window.location.origin}/auth/reset-password`
+                                        : undefined;
+                                await authClient.$fetch("/api/auth/request-password-reset", {
+                                        method: "POST",
+                                        body: {
+                                                email,
+                                                redirectTo,
+                                        },
+                                });
+                                toast.success("Password reset email sent");
+                        } catch (error) {
+                                toast.error(error instanceof Error ? error.message : "Unable to send reset email");
+                        } finally {
+                                setResettingUserId(null);
+                        }
+                },
+                [],
+        );
+
+        return (
+                <AppShell
+                        breadcrumbs={[
+                                { label: "Admin", href: "/admin/overview" },
+                                { label: "Users", current: true },
+                        ]}
+                        headerRight={<UserAvatar />}
+                >
+                        <RedirectToSignIn />
+                        <Card>
+                                <CardHeader className="gap-4 md:flex md:items-start md:justify-between">
+                                        <div>
+                                                <CardTitle>User management</CardTitle>
+                                                <CardDescription>Search, filter, and manage every user across the workspace.</CardDescription>
+                                        </div>
+                                        <div className="flex flex-wrap items-center gap-2">
+                                                <Input
+                                                        value={search}
+                                                        onChange={(event) => setSearch(event.target.value)}
+                                                        placeholder="Search by name or email"
+                                                        className="w-64"
+                                                />
+                                                <DropdownMenu>
+                                                        <DropdownMenuTrigger asChild>
+                                                                <Button variant="outline" size="sm">
+                                                                        Roles
+                                                                        {selectedRoles.length > 0 ? (
+                                                                                <span className="ml-2 rounded-full bg-secondary px-1.5 py-0.5 text-xs">
+                                                                                        {selectedRoles.length}
+                                                                                </span>
+                                                                        ) : null}
+                                                                </Button>
+                                                        </DropdownMenuTrigger>
+                                                        <DropdownMenuContent className="w-56">
+                                                                <DropdownMenuLabel>Filter by role</DropdownMenuLabel>
+                                                                <DropdownMenuSeparator />
+                                                                {rolesQuery.data?.map((role) => (
+                                                                        <DropdownMenuCheckboxItem
+                                                                                key={role}
+                                                                                checked={selectedRoles.includes(role)}
+                                                                                onCheckedChange={() => handleToggleRole(role)}
+                                                                        >
+                                                                                {role}
+                                                                        </DropdownMenuCheckboxItem>
+                                                                ))}
+                                                                {rolesQuery.isLoading ? (
+                                                                        <DropdownMenuItem disabled>Loading roles…</DropdownMenuItem>
+                                                                ) : null}
+                                                                {rolesQuery.isError && !rolesQuery.data ? (
+                                                                        <DropdownMenuItem disabled>Unable to load roles</DropdownMenuItem>
+                                                                ) : null}
+                                                        </DropdownMenuContent>
+                                                </DropdownMenu>
+                                                <Select value={status} onValueChange={(value) => setStatus(value as typeof status)}>
+                                                        <SelectTrigger size="sm" className="w-36">
+                                                                <SelectValue />
+                                                        </SelectTrigger>
+                                                        <SelectContent>
+                                                                {statusOptions.map((option) => (
+                                                                        <SelectItem key={option.value} value={option.value}>
+                                                                                {option.label}
+                                                                        </SelectItem>
+                                                                ))}
+                                                        </SelectContent>
+                                                </Select>
+                                                <Select
+                                                        value={calendarId || "all"}
+                                                        onValueChange={(value) => {
+                                                                setCalendarId(value === "all" ? "" : value);
+                                                        }}
+                                                >
+                                                        <SelectTrigger size="sm" className="w-44">
+                                                                <SelectValue placeholder="All calendars" />
+                                                        </SelectTrigger>
+                                                        <SelectContent>
+                                                                <SelectItem value="all">All calendars</SelectItem>
+                                                                {calendarsQuery.data?.map((calendar) => (
+                                                                        <SelectItem key={calendar.id} value={calendar.id}>
+                                                                                {calendar.name}
+                                                                        </SelectItem>
+                                                                ))}
+                                                                {calendarsQuery.isLoading ? (
+                                                                        <SelectItem value="loading" disabled>
+                                                                                Loading calendars…
+                                                                        </SelectItem>
+                                                                ) : null}
+                                                        </SelectContent>
+                                                </Select>
+                                                <Select
+                                                        value={String(pageSize)}
+                                                        onValueChange={(value) => setPageSize(Number(value))}
+                                                >
+                                                        <SelectTrigger size="sm" className="w-28">
+                                                                <SelectValue placeholder="Page size" />
+                                                        </SelectTrigger>
+                                                        <SelectContent>
+                                                                {[10, 25, 50].map((size) => (
+                                                                        <SelectItem key={size} value={String(size)}>
+                                                                                {size} / page
+                                                                        </SelectItem>
+                                                                ))}
+                                                        </SelectContent>
+                                                </Select>
+                                                <Select
+                                                        value={sort.field}
+                                                        onValueChange={(value) =>
+                                                                setSort((current) => ({ field: value as SortField, dir: current.dir }))
+                                                        }
+                                                >
+                                                        <SelectTrigger size="sm" className="w-40">
+                                                                <SelectValue placeholder="Sort by" />
+                                                        </SelectTrigger>
+                                                        <SelectContent>
+                                                                <SelectItem value="createdAt">Created date</SelectItem>
+                                                                <SelectItem value="name">Name</SelectItem>
+                                                                <SelectItem value="email">Email</SelectItem>
+                                                        </SelectContent>
+                                                </Select>
+                                                <Button
+                                                        type="button"
+                                                        variant="outline"
+                                                        size="sm"
+                                                        onClick={() =>
+                                                                setSort((current) => ({
+                                                                        ...current,
+                                                                        dir: current.dir === "asc" ? "desc" : "asc",
+                                                                }))
+                                                        }
+                                                >
+                                                        {sort.dir === "asc" ? "Ascending" : "Descending"}
+                                                </Button>
+                                        </div>
+                                </CardHeader>
+                                <CardContent className="space-y-4">
+                                        {listQuery.isError ? (
+                                                <div className="rounded-md border border-destructive/20 bg-destructive/10 px-4 py-3 text-destructive">
+                                                        Unable to load users. {listQuery.error instanceof Error ? listQuery.error.message : "Please try again."}
+                                                </div>
+                                        ) : null}
+                                        <div className="overflow-x-auto">
+                                                <Table>
+                                                        <TableHeader className="sticky top-0 z-10 bg-card">
+                                                                <TableRow>
+                                                                        <TableHead className="min-w-[220px]">
+                                                                                <button
+                                                                                        type="button"
+                                                                                        className="flex items-center gap-1 font-medium"
+                                                                                        onClick={() => handleSort("name")}
+                                                                                >
+                                                                                        User
+                                                                                        {sort.field === "name" || sort.field === "email" ? (
+                                                                                                <SortIndicator direction={sort.dir} />
+                                                                                        ) : null}
+                                                                                </button>
+                                                                        </TableHead>
+                                                                        <TableHead>Roles</TableHead>
+                                                                        <TableHead>Calendars</TableHead>
+                                                                        <TableHead>Status</TableHead>
+                                                                        <TableHead>
+                                                                                <button
+                                                                                        type="button"
+                                                                                        className="flex items-center gap-1 font-medium"
+                                                                                        onClick={() => handleSort("createdAt")}
+                                                                                >
+                                                                                        Created
+                                                                                        {sort.field === "createdAt" ? (
+                                                                                                <SortIndicator direction={sort.dir} />
+                                                                                        ) : null}
+                                                                                </button>
+                                                                        </TableHead>
+                                                                        <TableHead className="text-right">Actions</TableHead>
+                                                                </TableRow>
+                                                        </TableHeader>
+                                                        <TableBody>
+                                                                {isLoading ? (
+                                                                        Array.from({ length: Math.min(pageSize, 5) }).map((_, index) => (
+                                                                                <TableRow key={index}>
+                                                                                        <TableCell>
+                                                                                                <div className="flex items-center gap-3">
+                                                                                                        <div className="size-10 animate-pulse rounded-full bg-muted" />
+                                                                                                        <div className="space-y-2">
+                                                                                                                <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+                                                                                                                <div className="h-3 w-32 animate-pulse rounded bg-muted" />
+                                                                                                        </div>
+                                                                                                </div>
+                                                                                        </TableCell>
+                                                                                        <TableCell>
+                                                                                                <div className="flex gap-1">
+                                                                                                        <span className="h-5 w-12 animate-pulse rounded bg-muted" />
+                                                                                                        <span className="h-5 w-12 animate-pulse rounded bg-muted" />
+                                                                                                </div>
+                                                                                        </TableCell>
+                                                                                        <TableCell>
+                                                                                                <div className="flex gap-1">
+                                                                                                        <span className="h-5 w-14 animate-pulse rounded bg-muted" />
+                                                                                                        <span className="h-5 w-14 animate-pulse rounded bg-muted" />
+                                                                                                </div>
+                                                                                        </TableCell>
+                                                                                        <TableCell>
+                                                                                                <span className="h-5 w-16 animate-pulse rounded bg-muted" />
+                                                                                        </TableCell>
+                                                                                        <TableCell>
+                                                                                                <span className="h-5 w-20 animate-pulse rounded bg-muted" />
+                                                                                        </TableCell>
+                                                                                        <TableCell>
+                                                                                                <span className="ml-auto block h-8 w-12 animate-pulse rounded bg-muted" />
+                                                                                        </TableCell>
+                                                                                </TableRow>
+                                                                        ))
+                                                                ) : rows.length === 0 ? (
+                                                                        <TableRow>
+                                                                                <TableCell colSpan={6} className="py-12 text-center text-muted-foreground">
+                                                                                        No users found. Adjust your filters or try a different search.
+                                                                                </TableCell>
+                                                                        </TableRow>
+                                                                ) : (
+                                                                        rows.map((item) => {
+                                                                                const statusLabel = item.isBanned ? "Banned" : "Active";
+                                                                                const statusVariant = item.isBanned ? "destructive" : "secondary";
+                                                                                const createdDate = item.createdAt ? new Date(item.createdAt) : undefined;
+                                                                                const isBanning = banMutation.isPending && banMutation.variables?.userId === item.userId;
+                                                                                const isReactivating =
+                                                                                        reactivateMutation.isPending &&
+                                                                                        reactivateMutation.variables?.userId === item.userId;
+                                                                                const isResetting = resettingUserId === item.userId;
+
+                                                                                return (
+                                                                                        <TableRow key={item.userId}>
+                                                                                                <TableCell>
+                                                                                                        <div className="flex items-center gap-3">
+                                                                                                                <Avatar className="size-10">
+                                                                                                                        <AvatarImage src={item.avatarUrl} alt={item.name ?? item.email} />
+                                                                                                                        <AvatarFallback>{item.name?.charAt(0).toUpperCase() ?? item.email.charAt(0).toUpperCase()}</AvatarFallback>
+                                                                                                                </Avatar>
+                                                                                                                <div>
+                                                                                                                        <div className="font-medium text-sm text-foreground">{item.name || "Unnamed user"}</div>
+                                                                                                                        <Link
+                                                                                                                                href={`mailto:${item.email}`}
+                                                                                                                                className="text-muted-foreground text-sm hover:underline"
+                                                                                                                        >
+                                                                                                                                {item.email}
+                                                                                                                        </Link>
+                                                                                                                </div>
+                                                                                                        </div>
+                                                                                                </TableCell>
+                                                                                                <TableCell>
+                                                                                                        <div className="flex flex-wrap gap-2">
+                                                                                                                {item.roles.length === 0 ? (
+                                                                                                                        <Badge variant="outline">user</Badge>
+                                                                                                                ) : (
+                                                                                                                        item.roles.map((role) => (
+                                                                                                                                <Badge key={role} variant="outline">
+                                                                                                                                        {role}
+                                                                                                                                </Badge>
+                                                                                                                        ))
+                                                                                                                )}
+                                                                                                        </div>
+                                                                                                </TableCell>
+                                                                                                <TableCell>
+                                                                                                        <div className="flex flex-wrap gap-2">
+                                                                                                                {item.calendars.map((calendar) => (
+                                                                                                                        <Badge key={calendar.id} variant="secondary" className="max-w-[120px] truncate">
+                                                                                                                                <span title={calendar.name}>{calendar.name}</span>
+                                                                                                                        </Badge>
+                                                                                                                ))}
+                                                                                                                {item.calendarsOverflow > 0 ? (
+                                                                                                                        <Badge variant="outline">+{item.calendarsOverflow}</Badge>
+                                                                                                                ) : null}
+                                                                                                        </div>
+                                                                                                </TableCell>
+                                                                                                <TableCell>
+                                                                                                        <Badge variant={statusVariant}>{statusLabel}</Badge>
+                                                                                                </TableCell>
+                                                                                                <TableCell>
+                                                                                                        {createdDate ? (
+                                                                                                                <Tooltip>
+                                                                                                                        <TooltipTrigger asChild>
+                                                                                                                                <span className="cursor-default text-sm text-muted-foreground">
+                                                                                                                                        {formatDistanceToNow(createdDate, { addSuffix: true })}
+                                                                                                                                </span>
+                                                                                                                        </TooltipTrigger>
+                                                                                                                        <TooltipContent>{createdDate.toISOString()}</TooltipContent>
+                                                                                                                </Tooltip>
+                                                                                                        ) : (
+                                                                                                                <span className="text-muted-foreground text-sm">Unknown</span>
+                                                                                                        )}
+                                                                                                </TableCell>
+                                                                                                <TableCell className="text-right">
+                                                                                                        <DropdownMenu>
+                                                                                                                <DropdownMenuTrigger asChild>
+                                                                                                                        <Button
+                                                                                                                                variant="ghost"
+                                                                                                                                size="icon"
+                                                                                                                                className="size-8"
+                                                                                                                                aria-label="Open actions"
+                                                                                                                        >
+                                                                                                                                <MoreHorizontal className="size-4" />
+                                                                                                                        </Button>
+                                                                                                                </DropdownMenuTrigger>
+                                                                                                                <DropdownMenuContent align="end">
+                                                                                                                        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                                                                                                                        <DropdownMenuItem
+                                                                                                                                disabled={isResetting}
+                                                                                                                                onSelect={(event) => {
+                                                                                                                                        event.preventDefault();
+                                                                                                                                        void handleSendReset(item.userId, item.email);
+                                                                                                                                }}
+                                                                                                                        >
+                                                                                                                                Send password reset email
+                                                                                                                        </DropdownMenuItem>
+                                                                                                                        <DropdownMenuSeparator />
+                                                                                                                        {item.isBanned ? (
+                                                                                                                                <DropdownMenuItem
+                                                                                                                                        disabled={isReactivating}
+                                                                                                                                        onSelect={(event) => {
+                                                                                                                                                event.preventDefault();
+                                                                                                                                                reactivateMutation.mutate({ userId: item.userId });
+                                                                                                                                        }}
+                                                                                                                                >
+                                                                                                                                        Reactivate user
+                                                                                                                                </DropdownMenuItem>
+                                                                                                                        ) : (
+                                                                                                                                <DropdownMenuItem
+                                                                                                                                        disabled={isBanning}
+                                                                                                                                        onSelect={(event) => {
+                                                                                                                                                event.preventDefault();
+                                                                                                                                                banMutation.mutate({ userId: item.userId });
+                                                                                                                                        }}
+                                                                                                                                >
+                                                                                                                                        Ban user
+                                                                                                                                </DropdownMenuItem>
+                                                                                                                        )}
+                                                                                                                </DropdownMenuContent>
+                                                                                                        </DropdownMenu>
+                                                                                                </TableCell>
+                                                                                        </TableRow>
+                                                                                );
+                                                                        })
+                                                                )}
+                                                        </TableBody>
+                                                </Table>
+                                        </div>
+                                        {listQuery.data ? (
+                                                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                                        <div className="text-sm text-muted-foreground">
+                                                                Showing {summaryStart} to {summaryEnd} of {listQuery.data.total} users
+                                                        </div>
+                                                        <Pagination>
+                                                                <PaginationContent>
+                                                                        <PaginationItem>
+                                                                                <PaginationPrevious
+                                                                                        href="#"
+                                                                                        onClick={(event) => {
+                                                                                                event.preventDefault();
+                                                                                                setPage((prev) => Math.max(1, prev - 1));
+                                                                                        }}
+                                                                                        aria-disabled={page === 1}
+                                                                                        className={page === 1 ? "pointer-events-none opacity-50" : undefined}
+                                                                                />
+                                                                        </PaginationItem>
+                                                                        <PaginationItem>
+                                                                                <PaginationLink href="#" isActive>
+                                                                                        {page}
+                                                                                </PaginationLink>
+                                                                        </PaginationItem>
+                                                                        <PaginationItem>
+                                                                                <PaginationNext
+                                                                                        href="#"
+                                                                                        onClick={(event) => {
+                                                                                                event.preventDefault();
+                                                                                                setPage((prev) => Math.min(totalPages, prev + 1));
+                                                                                        }}
+                                                                                        aria-disabled={page >= totalPages}
+                                                                                        className={page >= totalPages ? "pointer-events-none opacity-50" : undefined}
+                                                                                />
+                                                                        </PaginationItem>
+                                                                </PaginationContent>
+                                                        </Pagination>
+                                                </div>
+                                        ) : null}
+                                </CardContent>
+                        </Card>
+                </AppShell>
+        );
+}
+
+type SortIndicatorProps = { direction: SortDir };
+
+function SortIndicator({ direction }: SortIndicatorProps) {
+        return (
+                <span aria-hidden className="text-muted-foreground text-xs">
+                        {direction === "asc" ? "▲" : "▼"}
+                </span>
+        );
+}

--- a/apps/server/src/components/admin/RequireAdmin.tsx
+++ b/apps/server/src/components/admin/RequireAdmin.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import * as React from "react";
+import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { authClient } from "@/lib/auth-client";
+
+export function RequireAdmin({ children }: { children: React.ReactNode }) {
+        const router = useRouter();
+        const { data: session, isPending } = authClient.useSession();
+        const [isAuthorized, setIsAuthorized] = React.useState(false);
+        const [hasChecked, setHasChecked] = React.useState(false);
+
+        React.useEffect(() => {
+                if (isPending) return;
+
+                setHasChecked(true);
+                if (!session) {
+                        router.replace("/auth/sign-in");
+                        return;
+                }
+
+                const roles = Array.isArray(session.user?.roles)
+                        ? session.user?.roles
+                        : session.user?.role
+                                ? [session.user.role]
+                                : [];
+
+                if (!roles?.includes("admin")) {
+                        toast.error("Administrator access required");
+                        router.replace("/");
+                        return;
+                }
+
+                setIsAuthorized(true);
+        }, [isPending, router, session]);
+
+        if (!hasChecked || isPending) {
+                return (
+                        <div className="flex w-full justify-center py-16 text-muted-foreground">
+                                <Loader2 className="size-5 animate-spin" aria-label="Checking permissions" />
+                        </div>
+                );
+        }
+
+        if (!isAuthorized) {
+                return null;
+        }
+
+        return <>{children}</>;
+}

--- a/apps/server/src/components/ui/dropdown-menu.tsx
+++ b/apps/server/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+        return <DropdownMenuPrimitive.Root data-slot="dropdown" {...props} />;
+}
+
+function DropdownMenuTrigger({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+        return <DropdownMenuPrimitive.Trigger data-slot="dropdown-trigger" {...props} />;
+}
+
+function DropdownMenuGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+        return <DropdownMenuPrimitive.Group data-slot="dropdown-group" {...props} />;
+}
+
+function DropdownMenuPortal({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+        return <DropdownMenuPrimitive.Portal data-slot="dropdown-portal" {...props} />;
+}
+
+function DropdownMenuSub({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+        return <DropdownMenuPrimitive.Sub data-slot="dropdown-sub" {...props} />;
+}
+
+function DropdownMenuRadioGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+        return <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-radio-group" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+        className,
+        inset,
+        children,
+        ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & { inset?: boolean }) {
+        return (
+                <DropdownMenuPrimitive.SubTrigger
+                        data-slot="dropdown-sub-trigger"
+                        className={cn(
+                                "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+                                inset && "pl-8",
+                                className,
+                        )}
+                        {...props}
+                >
+                        {children}
+                        <ChevronRight className="ml-auto size-4" />
+                </DropdownMenuPrimitive.SubTrigger>
+        );
+}
+
+function DropdownMenuSubContent({ className, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+        return (
+                <DropdownMenuPrimitive.SubContent
+                        data-slot="dropdown-sub-content"
+                        className={cn(
+                                "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+                                className,
+                        )}
+                        {...props}
+                />
+        );
+}
+
+function DropdownMenuContent({
+        className,
+        sideOffset = 4,
+        ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+        return (
+                <DropdownMenuPortal>
+                        <DropdownMenuPrimitive.Content
+                                data-slot="dropdown-content"
+                                sideOffset={sideOffset}
+                                className={cn(
+                                        "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+                                        className,
+                                )}
+                                {...props}
+                        />
+                </DropdownMenuPortal>
+        );
+}
+
+function DropdownMenuItem({
+        className,
+        inset,
+        ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & { inset?: boolean }) {
+        return (
+                <DropdownMenuPrimitive.Item
+                        data-slot="dropdown-item"
+                        className={cn(
+                                "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+                                inset && "pl-8",
+                                className,
+                        )}
+                        {...props}
+                />
+        );
+}
+
+function DropdownMenuCheckboxItem({
+        className,
+        children,
+        checked,
+        ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+        return (
+                <DropdownMenuPrimitive.CheckboxItem
+                        data-slot="dropdown-checkbox-item"
+                        className={cn(
+                                "relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+                                className,
+                        )}
+                        checked={checked}
+                        {...props}
+                >
+                        <span className="absolute left-2 flex size-3.5 items-center justify-center">
+                                <DropdownMenuPrimitive.ItemIndicator>
+                                        <Check className="size-4" />
+                                </DropdownMenuPrimitive.ItemIndicator>
+                        </span>
+                        {children}
+                </DropdownMenuPrimitive.CheckboxItem>
+        );
+}
+
+function DropdownMenuRadioItem({ className, children, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+        return (
+                <DropdownMenuPrimitive.RadioItem
+                        data-slot="dropdown-radio-item"
+                        className={cn(
+                                "relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+                                className,
+                        )}
+                        {...props}
+                >
+                        <span className="absolute left-2 flex size-3.5 items-center justify-center">
+                                <DropdownMenuPrimitive.ItemIndicator>
+                                        <Circle className="size-2 fill-current" />
+                                </DropdownMenuPrimitive.ItemIndicator>
+                        </span>
+                        {children}
+                </DropdownMenuPrimitive.RadioItem>
+        );
+}
+
+function DropdownMenuLabel({ className, inset, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & { inset?: boolean }) {
+        return (
+                <DropdownMenuPrimitive.Label
+                        data-slot="dropdown-label"
+                        className={cn("px-2 py-1.5 text-muted-foreground text-xs", inset && "pl-8", className)}
+                        {...props}
+                />
+        );
+}
+
+function DropdownMenuSeparator({ className, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+        return (
+                <DropdownMenuPrimitive.Separator
+                        data-slot="dropdown-separator"
+                        className={cn("-mx-1 my-1 h-px bg-border", className)}
+                        {...props}
+                />
+        );
+}
+
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {
+        return (
+                <span
+                        data-slot="dropdown-shortcut"
+                        className={cn("ml-auto text-muted-foreground text-xs tracking-widest", className)}
+                        {...props}
+                />
+        );
+}
+
+export {
+        DropdownMenu,
+        DropdownMenuTrigger,
+        DropdownMenuContent,
+        DropdownMenuItem,
+        DropdownMenuCheckboxItem,
+        DropdownMenuRadioGroup,
+        DropdownMenuRadioItem,
+        DropdownMenuLabel,
+        DropdownMenuSeparator,
+        DropdownMenuShortcut,
+        DropdownMenuGroup,
+        DropdownMenuPortal,
+        DropdownMenuSub,
+        DropdownMenuSubContent,
+        DropdownMenuSubTrigger,
+};

--- a/apps/server/src/config/ui.ts
+++ b/apps/server/src/config/ui.ts
@@ -22,7 +22,7 @@ export const defaultNavigation: NavGroup[] = [
 	{
 		label: "Admin",
 		items: [
-			{ title: "Users", href: "#users", icon: Users },
+                        { title: "Users", href: "/admin/users", icon: Users },
 			{ title: "Providers", href: "/admin/providers", icon: Network },
 			{ title: "Security", href: "#security", icon: ShieldCheck },
 			{ title: "Reports", href: "#reports", icon: BarChart3 },

--- a/apps/server/src/lib/trpc.ts
+++ b/apps/server/src/lib/trpc.ts
@@ -1,16 +1,16 @@
 import { initTRPC, TRPCError } from "@trpc/server";
 import type { Context } from "./context";
 
-export const t = initTRPC.context<Context>().create();
+const t = initTRPC.context<Context>().create();
 
 export const router = t.router;
 
 export const publicProcedure = t.procedure;
 
 export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
-	if (!ctx.session) {
-		throw new TRPCError({
-			code: "UNAUTHORIZED",
+        if (!ctx.session) {
+                throw new TRPCError({
+                        code: "UNAUTHORIZED",
 			message: "Authentication required",
 			cause: "No session",
 		});
@@ -20,5 +20,22 @@ export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
 			...ctx,
 			session: ctx.session,
 		},
-	});
+        });
+});
+
+export const adminProcedure = protectedProcedure.use(({ ctx, next }) => {
+        const roleCandidates = Array.isArray(ctx.session.user?.roles)
+                ? ctx.session.user.roles
+                : ctx.session.user?.role
+                        ? [ctx.session.user.role]
+                        : [];
+
+        if (!roleCandidates?.includes("admin")) {
+                throw new TRPCError({
+                        code: "FORBIDDEN",
+                        message: "Administrator permissions are required",
+                });
+        }
+
+        return next();
 });

--- a/apps/server/src/routers/admin-users.ts
+++ b/apps/server/src/routers/admin-users.ts
@@ -1,0 +1,231 @@
+import { and, asc, count, desc, eq, ilike, inArray, isNull, or } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import { db } from "@/db";
+import { member, organization, user } from "@/db/schema/auth";
+import { adminProcedure, router } from "@/lib/trpc";
+
+const listInputSchema = z.object({
+        q: z.string().trim().optional(),
+        roles: z.array(z.string().min(1)).optional(),
+        status: z.enum(["active", "banned", "all"]).optional(),
+        calendarId: z.string().min(1).optional(),
+        page: z.number().int().positive().optional(),
+        pageSize: z.number().int().min(1).max(100).optional(),
+        sort: z
+                .object({
+                        field: z.enum(["createdAt", "name", "email"]),
+                        dir: z.enum(["asc", "desc"]),
+                })
+                .optional(),
+});
+
+const defaultRoles = ["admin", "user"] as const;
+
+export const adminUsersRouter = router({
+        list: adminProcedure.input(listInputSchema).query(async ({ input }) => {
+                const page = input.page ?? 1;
+                const pageSize = input.pageSize ?? 25;
+                const sortField = input.sort?.field ?? "createdAt";
+                const sortDir = input.sort?.dir ?? "desc";
+
+                const calendarUserIds = input.calendarId
+                        ? await db
+                                        .select({ userId: member.userId })
+                                        .from(member)
+                                        .where(eq(member.organizationId, input.calendarId))
+                        : null;
+
+                if (calendarUserIds && calendarUserIds.length === 0) {
+                        return {
+                                items: [],
+                                total: 0,
+                                page,
+                                pageSize,
+                        };
+                }
+
+                const conditions: Array<ReturnType<typeof eq>> = [];
+
+                if (input.q) {
+                        const term = `%${input.q}%`;
+                        conditions.push(or(ilike(user.name, term), ilike(user.email, term)));
+                }
+
+                if (input.roles?.length) {
+                        conditions.push(inArray(user.role, input.roles));
+                }
+
+                if (input.status === "active") {
+                        conditions.push(or(eq(user.banned, false), isNull(user.banned)));
+                } else if (input.status === "banned") {
+                        conditions.push(eq(user.banned, true));
+                }
+
+                if (calendarUserIds) {
+                        const ids = calendarUserIds.map((row) => row.userId);
+                        conditions.push(inArray(user.id, ids));
+                }
+
+                const whereClause = conditions.length ? and(...conditions) : undefined;
+
+                let orderByExpression;
+                if (sortField === "name") {
+                        orderByExpression = sortDir === "asc" ? asc(user.name) : desc(user.name);
+                } else if (sortField === "email") {
+                        orderByExpression = sortDir === "asc" ? asc(user.email) : desc(user.email);
+                } else {
+                        orderByExpression = sortDir === "asc" ? asc(user.createdAt) : desc(user.createdAt);
+                }
+
+                const totalQuery = db.select({ value: count(user.id) }).from(user);
+                const usersQuery = db
+                        .select({
+                                id: user.id,
+                                name: user.name,
+                                email: user.email,
+                                image: user.image,
+                                role: user.role,
+                                banned: user.banned,
+                                createdAt: user.createdAt,
+                        })
+                        .from(user)
+                        .orderBy(orderByExpression)
+                        .limit(pageSize)
+                        .offset((page - 1) * pageSize);
+
+                const filteredTotalQuery = whereClause ? totalQuery.where(whereClause) : totalQuery;
+                const filteredUsersQuery = whereClause ? usersQuery.where(whereClause) : usersQuery;
+
+                const [totalResult, rows] = await Promise.all([
+                        filteredTotalQuery,
+                        filteredUsersQuery,
+                ]);
+
+                const total = Number(totalResult[0]?.value ?? 0);
+
+                if (rows.length === 0) {
+                        return {
+                                items: [],
+                                total,
+                                page,
+                                pageSize,
+                        };
+                }
+
+                const userIds = rows.map((row) => row.id);
+                const calendarRows = await db
+                        .select({
+                                userId: member.userId,
+                                calendarId: organization.id,
+                                name: organization.name,
+                                slug: organization.slug,
+                        })
+                        .from(member)
+                        .innerJoin(organization, eq(member.organizationId, organization.id))
+                        .where(inArray(member.userId, userIds));
+
+                const calendarMap = new Map<
+                        string,
+                        { calendars: Array<{ id: string; name: string; slug: string }>; overflow: number }
+                >();
+
+                for (const calendar of calendarRows) {
+                        const entry = calendarMap.get(calendar.userId) ?? {
+                                calendars: [],
+                                overflow: 0,
+                        };
+
+                        if (entry.calendars.length < 5) {
+                                entry.calendars.push({
+                                        id: calendar.calendarId,
+                                        name: calendar.name,
+                                        slug: calendar.slug,
+                                });
+                        } else {
+                                entry.overflow += 1;
+                        }
+
+                        calendarMap.set(calendar.userId, entry);
+                }
+
+                return {
+                        items: rows.map((row) => {
+                                const calendarInfo = calendarMap.get(row.id) ?? {
+                                        calendars: [],
+                                        overflow: 0,
+                                };
+
+                                return {
+                                        userId: row.id,
+                                        name: row.name,
+                                        email: row.email,
+                                        avatarUrl: row.image ?? undefined,
+                                        roles: row.role ? [row.role] : [],
+                                        isBanned: !!row.banned,
+                                        calendars: calendarInfo.calendars,
+                                        calendarsOverflow: calendarInfo.overflow,
+                                        createdAt: row.createdAt?.toISOString?.() ?? new Date().toISOString(),
+                                };
+                        }),
+                        total,
+                        page,
+                        pageSize,
+                };
+        }),
+        rolesOptions: adminProcedure.query(async () => {
+                const rows = await db.select({ role: user.role }).from(user).groupBy(user.role);
+                const roles = new Set<string>();
+                for (const role of defaultRoles) {
+                        roles.add(role);
+                }
+                for (const row of rows) {
+                        if (row.role) {
+                                roles.add(row.role);
+                        }
+                }
+                return Array.from(roles).sort();
+        }),
+        calendarsOptions: adminProcedure.query(async () => {
+                const calendars = await db
+                        .select({ id: organization.id, name: organization.name, slug: organization.slug })
+                        .from(organization)
+                        .orderBy(asc(organization.name));
+                return calendars.map((calendar) => ({
+                        id: calendar.id,
+                        name: calendar.name,
+                        slug: calendar.slug,
+                }));
+        }),
+        ban: adminProcedure
+                .input(z.object({ userId: z.string().min(1) }))
+                .mutation(async ({ input }) => {
+                        const result = await db
+                                .update(user)
+                                .set({ banned: true, updatedAt: new Date() })
+                                .where(eq(user.id, input.userId))
+                                .returning({ id: user.id });
+
+                        if (result.length === 0) {
+                                throw new TRPCError({ code: "NOT_FOUND", message: "User not found" });
+                        }
+
+                        return { ok: true };
+                }),
+        reactivate: adminProcedure
+                .input(z.object({ userId: z.string().min(1) }))
+                .mutation(async ({ input }) => {
+                        const result = await db
+                                .update(user)
+                                .set({ banned: false, banReason: null, banExpires: null, updatedAt: new Date() })
+                                .where(eq(user.id, input.userId))
+                                .returning({ id: user.id });
+
+                        if (result.length === 0) {
+                                throw new TRPCError({ code: "NOT_FOUND", message: "User not found" });
+                        }
+
+                        return { ok: true };
+                }),
+});

--- a/apps/server/src/routers/index.ts
+++ b/apps/server/src/routers/index.ts
@@ -1,5 +1,6 @@
 import { protectedProcedure, publicProcedure, router } from "../lib/trpc";
 import { providersRouter } from "./providers";
+import { adminUsersRouter } from "./admin-users";
 
 export const appRouter = router({
 	healthCheck: publicProcedure.query(() => {
@@ -11,6 +12,7 @@ export const appRouter = router({
 			user: ctx.session.user,
 		};
 	}),
-	providers: providersRouter,
+        providers: providersRouter,
+        adminUsers: adminUsersRouter,
 });
 export type AppRouter = typeof appRouter;

--- a/apps/server/src/routers/providers.ts
+++ b/apps/server/src/routers/providers.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { db } from "@/db";
 import { organizationProvider, provider } from "@/db/schema/app";
 import { member, organization } from "@/db/schema/auth";
-import { protectedProcedure, router } from "@/lib/trpc";
+import { adminProcedure, router } from "@/lib/trpc";
 
 const providerStatuses = ["draft", "beta", "active", "deprecated"] as const;
 
@@ -226,7 +226,7 @@ const providerIdInput = z.object({
 
 export const providersRouter = router({
   catalog: router({
-    list: protectedProcedure.query(async ({ ctx }) => {
+  list: adminProcedure.query(async ({ ctx }) => {
       if (!ctx.session) {
         throw new TRPCError({ code: "UNAUTHORIZED" });
       }
@@ -244,7 +244,7 @@ export const providersRouter = router({
         lastTestedAt: row.lastTestedAt ?? null,
       }));
     }),
-    get: protectedProcedure
+  get: adminProcedure
       .input(providerIdInput)
       .query(async ({ ctx, input }) => {
         if (!ctx.session) {
@@ -265,7 +265,7 @@ export const providersRouter = router({
           config: redactConfig(record.config),
         };
       }),
-    upsert: protectedProcedure
+  upsert: adminProcedure
       .input(
         z.object({
           id: z.string().min(1).optional(),
@@ -322,7 +322,7 @@ export const providersRouter = router({
 
         return { id: providerId };
       }),
-    delete: protectedProcedure
+  delete: adminProcedure
       .input(providerIdInput)
       .mutation(async ({ ctx, input }) => {
         if (!ctx.session) {
@@ -335,7 +335,7 @@ export const providersRouter = router({
 
         return { ok: true } as const;
       }),
-    testImap: protectedProcedure
+  testImap: adminProcedure
       .input(
         z.object({
           providerId: z.string().min(1).optional(),
@@ -363,7 +363,7 @@ export const providersRouter = router({
 
         return { ok: true } as const;
       }),
-    testSmtp: protectedProcedure
+  testSmtp: adminProcedure
       .input(
         z.object({
           providerId: z.string().min(1).optional(),
@@ -393,7 +393,7 @@ export const providersRouter = router({
       }),
   }),
   org: router({
-    list: protectedProcedure
+  list: adminProcedure
       .input(
         z.object({ slug: z.string().min(1, "Organization slug is required") }),
       )
@@ -429,7 +429,7 @@ export const providersRouter = router({
           })),
         };
       }),
-    link: protectedProcedure
+  link: adminProcedure
       .input(
         z.object({
           slug: z.string().min(1, "Organization slug is required"),


### PR DESCRIPTION
## Summary
* enforce admin-only access in the admin layout and expose a reusable RequireAdmin client guard
* add an adminUsers tRPC router with list, filter option, and ban/reactivate mutations
* build the /admin/users page with shadcn UI controls, React Query wiring, and dropdown actions for password reset and bans
* add a dropdown menu UI primitive and update navigation plus admin procedure usage

## Testing
* `bun run --filter server build` *(fails: Next.js cannot download Geist fonts in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cd30e85aac8327a345bd9e0ba0ddb8