### PR TITLE
Add admin log streaming console

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ First, install the dependencies:
 ```bash
 bun install
 ```
+
+## Monitoring worker activity
+
+Administrators can open [`/admin/logs`](apps/server/src/app/(site)/admin/logs/page.tsx) in the admin console to watch worker sessions in real time. The page keeps a live Server-Sent Events (SSE) subscription open to the server, streams new rows from the `worker_log` table into the UI, and augments them with history fetched through tRPC. The SSE channel is strictly one-way for monitoring purposes—no writes or admin actions are performed over the stream.
 ## Database Setup
 
 This project uses PostgreSQL with Drizzle ORM.

--- a/apps/server/.gitignore
+++ b/apps/server/.gitignore
@@ -36,6 +36,10 @@ node_modules/
 
 # logs
 logs/
+!src/app/(api)/admin/logs/
+!src/app/(api)/admin/logs/**
+!src/app/(site)/admin/logs/
+!src/app/(site)/admin/logs/**
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -47,6 +47,7 @@
 		"date-fns": "^4.1.0",
 		"dotenv": "^17.2.1",
 		"drizzle-orm": "^0.44.2",
+		"hono": "^4.9.8",
 		"imapflow": "^1.0.0",
 		"input-otp": "^1.4.2",
 		"lucide-react": "^0.544.0",

--- a/apps/server/src/app/(api)/admin/logs/stream/route.ts
+++ b/apps/server/src/app/(api)/admin/logs/stream/route.ts
@@ -1,0 +1,135 @@
+import { type SQL, and, asc, eq, gt } from "drizzle-orm";
+import { Hono } from "hono";
+import { handle } from "hono/vercel";
+import { streamSSE } from "hono/streaming";
+
+import { db } from "@/db";
+import { workerLog } from "@/db/schema/app";
+import { createContext } from "@/lib/context";
+
+const app = new Hono();
+
+app.use(async (c, next) => {
+        const context = await createContext(c.req.raw);
+
+        if (!context.session) {
+                return c.json({ error: "Unauthorized" }, 401);
+        }
+
+        const roleCandidates = Array.isArray(context.session.user?.roles)
+                ? context.session.user.roles
+                : context.session.user?.role
+                        ? [context.session.user.role]
+                        : [];
+
+        if (!roleCandidates.includes("admin")) {
+                return c.json({ error: "Forbidden" }, 403);
+        }
+
+        c.set("session", context.session);
+        await next();
+});
+
+app.get(async (c) => {
+        const url = new URL(c.req.url);
+        const providerId = url.searchParams.get("providerId") ?? undefined;
+        const level = url.searchParams.get("level") ?? undefined;
+        const sinceParam = url.searchParams.get("since") ?? undefined;
+
+        const parsedSince = sinceParam ? new Date(sinceParam) : undefined;
+        const since = parsedSince && !Number.isNaN(parsedSince.valueOf()) ? parsedSince : undefined;
+
+        const lastEventIdHeader = c.req.header("last-event-id");
+        let lastSeenId = lastEventIdHeader ? Number(lastEventIdHeader) : undefined;
+
+        if (Number.isNaN(lastSeenId)) {
+                lastSeenId = undefined;
+        }
+
+        let lastSeenTs = since ?? (lastSeenId ? undefined : new Date());
+
+        return streamSSE(c, async (stream) => {
+                let active = true;
+                const abortSignal = c.req.raw.signal;
+
+                const heartbeat = setInterval(() => {
+                        void stream.writeSSE({ event: "ping", data: "" });
+                }, 15000);
+
+                abortSignal.addEventListener("abort", () => {
+                        active = false;
+                        clearInterval(heartbeat);
+                });
+
+                const fetchAndSend = async () => {
+                        if (!active) return;
+
+                        const whereClauses: SQL[] = [];
+
+                        if (providerId) {
+                                whereClauses.push(eq(workerLog.providerId, providerId));
+                        }
+
+                        if (level) {
+                                whereClauses.push(eq(workerLog.level, level));
+                        }
+
+                        if (lastSeenId != null) {
+                                whereClauses.push(gt(workerLog.id, lastSeenId));
+                        } else if (lastSeenTs) {
+                                whereClauses.push(gt(workerLog.ts, lastSeenTs));
+                        }
+
+                        const rows = await db
+                                .select()
+                                .from(workerLog)
+                                .where(whereClauses.length ? and(...whereClauses) : undefined)
+                                .orderBy(asc(workerLog.id))
+                                .limit(100);
+
+                        for (const row of rows) {
+                                if (!active) {
+                                        break;
+                                }
+
+                                lastSeenId = row.id;
+                                lastSeenTs = row.ts instanceof Date ? row.ts : new Date(row.ts);
+
+                                try {
+                                        await stream.writeSSE({
+                                                id: row.id.toString(),
+                                                event: "log",
+                                                data: JSON.stringify({
+                                                        id: row.id,
+                                                        ts:
+                                                                row.ts instanceof Date
+                                                                        ? row.ts.toISOString()
+                                                                        : row.ts,
+                                                        level: row.level,
+                                                        providerId: row.providerId,
+                                                        sessionId: row.sessionId,
+                                                        msg: row.msg,
+                                                        data: row.data,
+                                                }),
+                                        });
+                                } catch (error) {
+                                        active = false;
+                                        break;
+                                }
+                        }
+                };
+
+                try {
+                        await fetchAndSend();
+
+                        while (active) {
+                                await stream.sleep(2000);
+                                await fetchAndSend();
+                        }
+                } finally {
+                        clearInterval(heartbeat);
+                }
+        });
+});
+
+export const GET = handle(app);

--- a/apps/server/src/app/(site)/admin/logs/page.tsx
+++ b/apps/server/src/app/(site)/admin/logs/page.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { RedirectToSignIn } from "@daveyplate/better-auth-ui";
+import { format } from "date-fns";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import AppShell from "@/components/layout/AppShell";
+import { UserAvatar } from "@/components/UserAvatar";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+        Card,
+        CardContent,
+        CardDescription,
+        CardHeader,
+        CardTitle,
+} from "@/components/ui/card";
+import {
+        Dialog,
+        DialogContent,
+        DialogDescription,
+        DialogHeader,
+        DialogTitle,
+        DialogTrigger,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+        Table,
+        TableBody,
+        TableCell,
+        TableHead,
+        TableHeader,
+        TableRow,
+} from "@/components/ui/table";
+import { useCatalogList } from "@/hooks/use-provider-admin";
+import { useAdminLogStream, useAdminLogs } from "@/hooks/use-admin-logs";
+
+const LOG_LEVELS = [
+        { value: "debug", label: "Debug" },
+        { value: "info", label: "Info" },
+        { value: "warn", label: "Warning" },
+        { value: "error", label: "Error" },
+];
+
+function formatTimestamp(value: Date | string | null | undefined) {
+        if (!value) return "";
+
+        const date = value instanceof Date ? value : new Date(value);
+
+        if (Number.isNaN(date.valueOf())) {
+                return "";
+        }
+
+        return format(date, "PPpp");
+}
+
+function getLevelBadgeVariant(level: string) {
+        const normalized = level.toLowerCase();
+
+        if (normalized === "error" || normalized === "fatal") {
+                return "destructive" as const;
+        }
+
+        if (normalized === "warn" || normalized === "warning") {
+                return "secondary" as const;
+        }
+
+        if (normalized === "debug") {
+                return "outline" as const;
+        }
+
+        return "default" as const;
+}
+
+export default function AdminLogsPage() {
+        const [providerFilter, setProviderFilter] = useState<string | null>(null);
+        const [levelFilter, setLevelFilter] = useState<string | null>(null);
+
+        const providerQuery = useCatalogList();
+        const logsQuery = useAdminLogs({ providerId: providerFilter, level: levelFilter });
+
+        const { fetchNextPage, hasNextPage, isFetchingNextPage } = logsQuery;
+
+        const rows = logsQuery.data?.pages.flatMap((page) => page.logs) ?? [];
+        const latest = rows[0];
+
+        useAdminLogStream({ providerId: providerFilter, level: levelFilter }, latest);
+
+        const providerMap = useMemo(() => {
+                const map = new Map<string, string>();
+
+                if (providerQuery.data) {
+                        for (const provider of providerQuery.data) {
+                                map.set(provider.id, provider.name);
+                        }
+                }
+
+                return map;
+        }, [providerQuery.data]);
+
+        const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+        useEffect(() => {
+                const node = sentinelRef.current;
+
+                if (!node) return;
+
+                const observer = new IntersectionObserver((entries) => {
+                        const entry = entries[0];
+
+                        if (!entry?.isIntersecting) return;
+
+                        if (hasNextPage && !isFetchingNextPage) {
+                                void fetchNextPage();
+                        }
+                });
+
+                observer.observe(node);
+
+                return () => observer.disconnect();
+        }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+        const renderDataDialog = (data: unknown, id: number) => {
+                if (data == null) {
+                        return <span className="text-muted-foreground">-</span>;
+                }
+
+                return (
+                        <Dialog>
+                                <DialogTrigger asChild>
+                                        <Button variant="ghost" size="sm">
+                                                View
+                                        </Button>
+                                </DialogTrigger>
+                                <DialogContent className="max-w-2xl">
+                                        <DialogHeader>
+                                                <DialogTitle>Log data</DialogTitle>
+                                                <DialogDescription>
+                                                        Payload associated with worker log #{id}.
+                                                </DialogDescription>
+                                        </DialogHeader>
+                                        <pre className="mt-4 max-h-80 overflow-auto rounded bg-muted p-4 text-xs">
+                                                {JSON.stringify(data, null, 2)}
+                                        </pre>
+                                </DialogContent>
+                        </Dialog>
+                );
+        };
+
+        return (
+                <AppShell
+                        breadcrumbs={[
+                                { label: "Admin", href: "/admin/overview" },
+                                { label: "Logs", current: true },
+                        ]}
+                        headerRight={<UserAvatar />}
+                >
+                        <RedirectToSignIn />
+                        <Card>
+                                <CardHeader className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+                                        <div>
+                                                <CardTitle>Worker logs</CardTitle>
+                                                <CardDescription>
+                                                        Monitor worker sessions in real time with streaming updates.
+                                                </CardDescription>
+                                        </div>
+                                        <div className="flex flex-wrap items-end gap-4">
+                                                <div className="flex w-52 flex-col gap-2">
+                                                        <Label htmlFor="provider-filter">Provider</Label>
+                                                        {providerQuery.isLoading ? (
+                                                                <Skeleton className="h-10 w-full" />
+                                                        ) : (
+                                                                <Select
+                                                                        value={providerFilter ?? "all"}
+                                                                        onValueChange={(value) =>
+                                                                                setProviderFilter(value === "all" ? null : value)
+                                                                        }
+                                                                >
+                                                                        <SelectTrigger id="provider-filter">
+                                                                                <SelectValue placeholder="All providers" />
+                                                                        </SelectTrigger>
+                                                                        <SelectContent>
+                                                                                <SelectItem value="all">All providers</SelectItem>
+                                                                                {providerQuery.data?.map((provider) => (
+                                                                                        <SelectItem key={provider.id} value={provider.id}>
+                                                                                                {provider.name}
+                                                                                        </SelectItem>
+                                                                                ))}
+                                                                        </SelectContent>
+                                                                </Select>
+                                                        )}
+                                                </div>
+                                                <div className="flex w-52 flex-col gap-2">
+                                                        <Label htmlFor="level-filter">Level</Label>
+                                                        <Select
+                                                                value={levelFilter ?? "all"}
+                                                                onValueChange={(value) =>
+                                                                        setLevelFilter(value === "all" ? null : value)
+                                                                }
+                                                        >
+                                                                <SelectTrigger id="level-filter">
+                                                                        <SelectValue placeholder="All levels" />
+                                                                </SelectTrigger>
+                                                                <SelectContent>
+                                                                        <SelectItem value="all">All levels</SelectItem>
+                                                                        {LOG_LEVELS.map((option) => (
+                                                                                <SelectItem key={option.value} value={option.value}>
+                                                                                        {option.label}
+                                                                                </SelectItem>
+                                                                        ))}
+                                                                </SelectContent>
+                                                        </Select>
+                                                </div>
+                                        </div>
+                                </CardHeader>
+                                <CardContent>
+                                        {logsQuery.isError ? (
+                                                <Alert variant="destructive">
+                                                        <AlertTitle>Unable to load logs</AlertTitle>
+                                                        <AlertDescription>
+                                                                {logsQuery.error instanceof Error
+                                                                        ? logsQuery.error.message
+                                                                        : "Something went wrong while fetching logs."}
+                                                        </AlertDescription>
+                                                </Alert>
+                                        ) : logsQuery.isLoading ? (
+                                                <div className="space-y-3">
+                                                        {[0, 1, 2, 3, 4].map((index) => (
+                                                                <Skeleton key={index} className="h-16 w-full" />
+                                                        ))}
+                                                </div>
+                                        ) : rows.length === 0 ? (
+                                                <Alert>
+                                                        <AlertTitle>No logs yet</AlertTitle>
+                                                        <AlertDescription>
+                                                                Worker output will appear here as soon as new jobs run.
+                                                        </AlertDescription>
+                                                </Alert>
+                                        ) : (
+                                                <div className="space-y-4">
+                                                        <Table>
+                                                                <TableHeader>
+                                                                        <TableRow>
+                                                                                <TableHead className="w-48">Timestamp</TableHead>
+                                                                                <TableHead className="w-44">Provider</TableHead>
+                                                                                <TableHead className="w-40">Session</TableHead>
+                                                                                <TableHead className="w-28">Level</TableHead>
+                                                                                <TableHead>Message</TableHead>
+                                                                                <TableHead className="w-28">Data</TableHead>
+                                                                        </TableRow>
+                                                                </TableHeader>
+                                                                <TableBody>
+                                                                        {rows.map((row) => (
+                                                                                <TableRow key={row.id}>
+                                                                                        <TableCell className="font-mono text-xs">
+                                                                                                {formatTimestamp(row.ts)}
+                                                                                        </TableCell>
+                                                                                        <TableCell className="text-sm">
+                                                                                                {row.providerId
+                                                                                                        ? providerMap.get(row.providerId) ?? row.providerId
+                                                                                                        : "-"}
+                                                                                        </TableCell>
+                                                                                        <TableCell className="text-sm">
+                                                                                                {row.sessionId ?? "-"}
+                                                                                        </TableCell>
+                                                                                        <TableCell>
+                                                                                                <Badge variant={getLevelBadgeVariant(row.level)}>
+                                                                                                        {row.level.toUpperCase()}
+                                                                                                </Badge>
+                                                                                        </TableCell>
+                                                                                        <TableCell className="text-sm">
+                                                                                                {row.msg}
+                                                                                        </TableCell>
+                                                                                        <TableCell>{renderDataDialog(row.data, row.id)}</TableCell>
+                                                                                </TableRow>
+                                                                        ))}
+                                                                </TableBody>
+                                                        </Table>
+                                                        <div ref={sentinelRef} />
+                                                        {isFetchingNextPage ? (
+                                                                <p className="text-muted-foreground text-sm">
+                                                                        Loading more logs...
+                                                                </p>
+                                                        ) : null}
+                                                        {!hasNextPage && rows.length > 0 ? (
+                                                                <p className="text-muted-foreground text-sm">
+                                                                        You&apos;ve reached the end of the available history.
+                                                                </p>
+                                                        ) : null}
+                                                </div>
+                                        )}
+                                </CardContent>
+                        </Card>
+                </AppShell>
+        );
+}

--- a/apps/server/src/config/ui.ts
+++ b/apps/server/src/config/ui.ts
@@ -18,19 +18,18 @@ export const defaultNavigation: NavGroup[] = [
 			{ title: "Dashboard", href: "/admin/overview", icon: LayoutDashboard },
 			{ title: "Calendars", href: "/admin/cals", icon: CalendarDays },
 			{ title: "Users", href: "/admin/users", icon: Users },
-			{ title: "Providers", href: "/admin/providers", icon: Network },
-			//Implement the page
-			{ title: "Flags", href: "/admin/flags", icon: FlagIcon },
-		],
-	},
-	{
-		label: "Activities",
-		items: [
-			{ title: "Background", href: "/admin/background", icon: ShieldCheck },
-			{ title: "Jobs", href: "/admin/background/jobs", icon: BarChart3 },
-			{ title: "Logs", href: "/admin/background/logs", icon: MessageSquare },
-		],
-	},
+                        { title: "Providers", href: "/admin/providers", icon: Network },
+                        { title: "Flags", href: "/admin/flags", icon: FlagIcon },
+                        { title: "Logs", href: "/admin/logs", icon: MessageSquare },
+                ],
+        },
+        {
+                label: "Activities",
+                items: [
+                        { title: "Background", href: "/admin/background", icon: ShieldCheck },
+                        { title: "Jobs", href: "/admin/background/jobs", icon: BarChart3 },
+                ],
+        },
 ];
 
 export const highlights = [

--- a/apps/server/src/db/schema/app.ts
+++ b/apps/server/src/db/schema/app.ts
@@ -1,14 +1,15 @@
 import { sql } from "drizzle-orm";
 import {
-	boolean,
-	check,
-	integer,
-	jsonb,
-	pgEnum,
-	pgTable,
-	text,
-	timestamp,
-	uniqueIndex,
+        bigserial,
+        boolean,
+        check,
+        integer,
+        jsonb,
+        pgEnum,
+        pgTable,
+        text,
+        timestamp,
+        uniqueIndex,
 } from "drizzle-orm/pg-core";
 
 import { organization } from "./auth";
@@ -83,10 +84,10 @@ export const flag = pgTable(
 );
 
 export const event = pgTable(
-	"event",
-	{
-		id: text("id").primaryKey(),
-		provider: text("provider_id")
+        "event",
+        {
+                id: text("id").primaryKey(),
+                provider: text("provider_id")
 			.notNull()
 			.references(() => provider.id, { onDelete: "set null" }),
 		flag: text("flag_id").references(() => flag.id, { onDelete: "set null" }),
@@ -123,3 +124,15 @@ export const event = pgTable(
 
 export type Provider = typeof provider.$inferSelect;
 export type Event = typeof event.$inferSelect;
+
+export const workerLog = pgTable("worker_log", {
+        id: bigserial("id", { mode: "number" }).primaryKey(),
+        ts: timestamp("ts", { withTimezone: true }).notNull().defaultNow(),
+        level: text("level").notNull(),
+        providerId: text("provider_id"),
+        sessionId: text("session_id"),
+        msg: text("msg").notNull(),
+        data: jsonb("data").$type<Record<string, unknown> | null>(),
+});
+
+export type WorkerLog = typeof workerLog.$inferSelect;

--- a/apps/server/src/lib/context.ts
+++ b/apps/server/src/lib/context.ts
@@ -1,12 +1,11 @@
-import type { NextRequest } from "next/server";
 import { auth } from "./auth";
 
-export async function createContext(req: NextRequest) {
-	const session = await auth.api.getSession({
-		headers: req.headers,
-	});
-	return {
-		session,
+export async function createContext(req: Request) {
+        const session = await auth.api.getSession({
+                headers: req.headers,
+        });
+        return {
+                session,
 	};
 }
 

--- a/apps/server/src/lib/query-keys/logs.ts
+++ b/apps/server/src/lib/query-keys/logs.ts
@@ -1,0 +1,11 @@
+export type LogFilterParams = {
+        providerId?: string | null;
+        level?: string | null;
+        since?: string | null;
+};
+
+export const logsKeys = {
+        root: () => ["adminLogs"] as const,
+        list: (filters: LogFilterParams) =>
+                [...logsKeys.root(), { filters }] as const,
+};

--- a/apps/server/src/routers/admin-logs.ts
+++ b/apps/server/src/routers/admin-logs.ts
@@ -1,0 +1,71 @@
+import { type SQL, and, desc, eq, gt, lt } from "drizzle-orm";
+import { z } from "zod";
+
+import { db } from "@/db";
+import { workerLog } from "@/db/schema/app";
+import { adminProcedure, router } from "@/lib/trpc";
+
+const DEFAULT_PAGE_SIZE = 50;
+
+const filterSchema = z.object({
+        providerId: z.string().trim().min(1).optional(),
+        level: z.string().trim().min(1).optional(),
+        cursor: z.number().int().positive().optional(),
+        limit: z.number().int().min(1).max(200).optional(),
+        since: z
+                .string()
+                .datetime({ offset: true })
+                .optional()
+                .transform((value) => (value ? new Date(value) : undefined)),
+});
+
+export const adminLogsRouter = router({
+        list: adminProcedure
+                .input(filterSchema.optional())
+                .query(async ({ input }) => {
+                        const filters = input ?? {};
+                        const limit = filters.limit ?? DEFAULT_PAGE_SIZE;
+
+                        const whereClauses: SQL[] = [];
+
+                        if (filters.providerId) {
+                                whereClauses.push(eq(workerLog.providerId, filters.providerId));
+                        }
+
+                        if (filters.level) {
+                                whereClauses.push(eq(workerLog.level, filters.level));
+                        }
+
+                        if (filters.since) {
+                                whereClauses.push(gt(workerLog.ts, filters.since));
+                        }
+
+                        if (filters.cursor) {
+                                whereClauses.push(lt(workerLog.id, filters.cursor));
+                        }
+
+                        const rows = await db
+                                .select()
+                                .from(workerLog)
+                                .where(whereClauses.length ? and(...whereClauses) : undefined)
+                                .orderBy(desc(workerLog.id))
+                                .limit(limit + 1);
+
+                        const hasMore = rows.length > limit;
+                        const limitedRows = hasMore ? rows.slice(0, limit) : rows;
+
+                        const logs = limitedRows.map((row) => ({
+                                ...row,
+                                data: row.data ?? null,
+                        }));
+
+                        const nextCursor = hasMore
+                                ? logs[logs.length - 1]?.id ?? null
+                                : null;
+
+                        return {
+                                logs,
+                                nextCursor,
+                        };
+                }),
+});

--- a/apps/server/src/routers/index.ts
+++ b/apps/server/src/routers/index.ts
@@ -1,5 +1,6 @@
 import { protectedProcedure, publicProcedure, router } from "../lib/trpc";
 import { adminFlagsRouter } from "./admin-flags";
+import { adminLogsRouter } from "./admin-logs";
 import { adminUsersRouter } from "./admin-users";
 import { providersRouter } from "./providers";
 
@@ -13,8 +14,9 @@ export const appRouter = router({
 			user: ctx.session.user,
 		};
 	}),
-	providers: providersRouter,
-	adminUsers: adminUsersRouter,
-	adminFlags: adminFlagsRouter,
+        providers: providersRouter,
+        adminUsers: adminUsersRouter,
+        adminFlags: adminFlagsRouter,
+        adminLogs: adminLogsRouter,
 });
 export type AppRouter = typeof appRouter;

--- a/bun.lock
+++ b/bun.lock
@@ -7,19 +7,6 @@
         "@biomejs/biome": "^2.2.0",
       },
     },
-    "apps/mailertest": {
-      "name": "mailertest",
-      "dependencies": {
-        "nodemailer": "^7.0.6",
-      },
-      "devDependencies": {
-        "@types/bun": "latest",
-        "@types/nodemailer": "^7.0.1",
-      },
-      "peerDependencies": {
-        "typescript": "^5",
-      },
-    },
     "apps/server": {
       "name": "server",
       "version": "0.1.0",
@@ -54,6 +41,7 @@
         "date-fns": "^4.1.0",
         "dotenv": "^17.2.1",
         "drizzle-orm": "^0.44.2",
+        "hono": "^4.9.8",
         "imapflow": "^1.0.0",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.544.0",
@@ -801,6 +789,8 @@
 
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
 
+    "hono": ["hono@4.9.8", "", {}, "sha512-JW8Bb4RFWD9iOKxg5PbUarBYGM99IcxFl2FPBo2gSJO11jjUDqlP1Bmfyqt8Z/dGhIQ63PMA9LdcLefXyIasyg=="],
+
     "html-to-text": ["html-to-text@9.0.5", "", { "dependencies": { "@selderee/plugin-htmlparser2": "^0.11.0", "deepmerge": "^4.3.1", "dom-serializer": "^2.0.0", "htmlparser2": "^8.0.2", "selderee": "^0.11.0" } }, "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg=="],
 
     "htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
@@ -867,8 +857,6 @@
 
     "magic-string": ["magic-string@0.30.19", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw=="],
 
-    "mailertest": ["mailertest@workspace:apps/mailertest"],
-
     "mailparser": ["mailparser@3.7.4", "", { "dependencies": { "encoding-japanese": "2.2.0", "he": "1.2.0", "html-to-text": "9.0.5", "iconv-lite": "0.6.3", "libmime": "5.3.7", "linkify-it": "5.0.0", "mailsplit": "5.4.5", "nodemailer": "7.0.4", "punycode.js": "2.3.1", "tlds": "1.259.0" } }, "sha512-Beh4yyR4jLq3CZZ32asajByrXnW8dLyKCAQD3WvtTiBnMtFWhxO+wa93F6sJNjDmfjxXs4NRNjw3XAGLqZR3Vg=="],
 
     "mailsplit": ["mailsplit@5.4.6", "", { "dependencies": { "libbase64": "1.3.0", "libmime": "5.3.7", "libqp": "2.1.1" } }, "sha512-M+cqmzaPG/mEiCDmqQUz8L177JZLZmXAUpq38owtpq2xlXlTSw+kntnxRt2xsxVFFV6+T8Mj/U0l5s7s6e0rNw=="],
@@ -895,7 +883,7 @@
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
-    "nodemailer": ["nodemailer@7.0.6", "", {}, "sha512-F44uVzgwo49xboqbFgBGkRaiMgtoBrBEWCVincJPK9+S9Adkzt/wXCLKbf7dxucmxfTI5gHGB+bEmdyzN6QKjw=="],
+    "nodemailer": ["nodemailer@6.10.1", "", {}, "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA=="],
 
     "nuqs": ["nuqs@2.6.0", "", { "dependencies": { "@standard-schema/spec": "1.0.0" }, "peerDependencies": { "@remix-run/react": ">=2", "@tanstack/react-router": "^1", "next": ">=14.2.0", "react": ">=18.2.0 || ^19.0.0-0", "react-router": "^6 || ^7", "react-router-dom": "^6 || ^7" }, "optionalPeers": ["@remix-run/react", "@tanstack/react-router", "next", "react-router", "react-router-dom"] }, "sha512-EvIKBvfJeyL8n6lxfebxoAbkHJutNsxmy1oo4noFUYNUESbnecxWxgnxXoa0/4fYiFwdEuyMQx1Z9rV0h4bnkg=="],
 
@@ -1087,7 +1075,7 @@
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
-    "zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+    "zod": ["zod@4.1.9", "", {}, "sha512-HI32jTq0AUAC125z30E8bQNz0RQ+9Uc+4J7V97gLYjZVKRjeydPgGt6dvQzFrav7MYOUGFqqOGiHpA/fdbd0cQ=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
@@ -1117,6 +1105,10 @@
 
     "@types/mailparser/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
+    "better-auth/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+
+    "imapflow/nodemailer": ["nodemailer@7.0.6", "", {}, "sha512-F44uVzgwo49xboqbFgBGkRaiMgtoBrBEWCVincJPK9+S9Adkzt/wXCLKbf7dxucmxfTI5gHGB+bEmdyzN6QKjw=="],
+
     "libmime/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "mailparser/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
@@ -1127,11 +1119,7 @@
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
-    "server/nodemailer": ["nodemailer@6.10.1", "", {}, "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA=="],
-
     "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
-
-    "worker/zod": ["zod@4.1.9", "", {}, "sha512-HI32jTq0AUAC125z30E8bQNz0RQ+9Uc+4J7V97gLYjZVKRjeydPgGt6dvQzFrav7MYOUGFqqOGiHpA/fdbd0cQ=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 


### PR DESCRIPTION
## Summary
- add worker_log schema to Drizzle and expose a new adminLogs router for paginated queries
- expose a protected `/admin/logs/stream` SSE endpoint backed by Hono that streams filtered worker logs in real time
- build an admin Logs page with filters, live updates wired into React Query, and documentation for operators

## Testing
- NEXT_DISABLE_FONT_DOWNLOADS=1 bun run --filter server build *(fails: Next.js cannot download Geist fonts in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_b_68d2aae5e00c8327850e36cbd09a4544