### PR TITLE
Buffer admin log SSE events until initial data load

### DIFF
--- a/apps/server/src/app/(site)/admin/logs/page.tsx
+++ b/apps/server/src/app/(site)/admin/logs/page.tsx
@@ -2,7 +2,7 @@
 
 import { RedirectToSignIn } from "@daveyplate/better-auth-ui";
 import { format } from "date-fns";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 
 import AppShell from "@/components/layout/AppShell";
 import { UserAvatar } from "@/components/UserAvatar";
@@ -10,290 +10,305 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
-        Card,
-        CardContent,
-        CardDescription,
-        CardHeader,
-        CardTitle,
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
 } from "@/components/ui/card";
 import {
-        Dialog,
-        DialogContent,
-        DialogDescription,
-        DialogHeader,
-        DialogTitle,
-        DialogTrigger,
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
-        Table,
-        TableBody,
-        TableCell,
-        TableHead,
-        TableHeader,
-        TableRow,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
 } from "@/components/ui/table";
-import { useCatalogList } from "@/hooks/use-provider-admin";
 import { useAdminLogStream, useAdminLogs } from "@/hooks/use-admin-logs";
+import { useCatalogList } from "@/hooks/use-provider-admin";
 
 const LOG_LEVELS = [
-        { value: "debug", label: "Debug" },
-        { value: "info", label: "Info" },
-        { value: "warn", label: "Warning" },
-        { value: "error", label: "Error" },
+	{ value: "debug", label: "Debug" },
+	{ value: "info", label: "Info" },
+	{ value: "warn", label: "Warning" },
+	{ value: "error", label: "Error" },
 ];
 
 function formatTimestamp(value: Date | string | null | undefined) {
-        if (!value) return "";
+	if (!value) return "";
 
-        const date = value instanceof Date ? value : new Date(value);
+	const date = value instanceof Date ? value : new Date(value);
 
-        if (Number.isNaN(date.valueOf())) {
-                return "";
-        }
+	if (Number.isNaN(date.valueOf())) {
+		return "";
+	}
 
-        return format(date, "PPpp");
+	return format(date, "PPpp");
 }
 
 function getLevelBadgeVariant(level: string) {
-        const normalized = level.toLowerCase();
+	const normalized = level.toLowerCase();
 
-        if (normalized === "error" || normalized === "fatal") {
-                return "destructive" as const;
-        }
+	if (normalized === "error" || normalized === "fatal") {
+		return "destructive" as const;
+	}
 
-        if (normalized === "warn" || normalized === "warning") {
-                return "secondary" as const;
-        }
+	if (normalized === "warn" || normalized === "warning") {
+		return "secondary" as const;
+	}
 
-        if (normalized === "debug") {
-                return "outline" as const;
-        }
+	if (normalized === "debug") {
+		return "outline" as const;
+	}
 
-        return "default" as const;
+	return "default" as const;
 }
 
 export default function AdminLogsPage() {
-        const [providerFilter, setProviderFilter] = useState<string | null>(null);
-        const [levelFilter, setLevelFilter] = useState<string | null>(null);
+	const [providerFilter, setProviderFilter] = useState<string | null>(null);
+	const [levelFilter, setLevelFilter] = useState<string | null>(null);
 
-        const providerQuery = useCatalogList();
-        const logsQuery = useAdminLogs({ providerId: providerFilter, level: levelFilter });
+	const providerQuery = useCatalogList();
+	const logsQuery = useAdminLogs({
+		providerId: providerFilter,
+		level: levelFilter,
+	});
+	const providerSelectId = useId();
+	const levelSelectId = useId();
 
-        const { fetchNextPage, hasNextPage, isFetchingNextPage } = logsQuery;
+	const { fetchNextPage, hasNextPage, isFetchingNextPage } = logsQuery;
 
-        const rows = logsQuery.data?.pages.flatMap((page) => page.logs) ?? [];
-        const latest = rows[0];
+	const rows = logsQuery.data?.pages.flatMap((page) => page.logs) ?? [];
+	const latest = rows[0];
 
-        useAdminLogStream({ providerId: providerFilter, level: levelFilter }, latest);
+	useAdminLogStream(
+		{ providerId: providerFilter, level: levelFilter },
+		latest,
+		logsQuery.isPending,
+	);
 
-        const providerMap = useMemo(() => {
-                const map = new Map<string, string>();
+	const providerMap = useMemo(() => {
+		const map = new Map<string, string>();
 
-                if (providerQuery.data) {
-                        for (const provider of providerQuery.data) {
-                                map.set(provider.id, provider.name);
-                        }
-                }
+		if (providerQuery.data) {
+			for (const provider of providerQuery.data) {
+				map.set(provider.id, provider.name);
+			}
+		}
 
-                return map;
-        }, [providerQuery.data]);
+		return map;
+	}, [providerQuery.data]);
 
-        const sentinelRef = useRef<HTMLDivElement | null>(null);
+	const sentinelRef = useRef<HTMLDivElement | null>(null);
 
-        useEffect(() => {
-                const node = sentinelRef.current;
+	useEffect(() => {
+		const node = sentinelRef.current;
 
-                if (!node) return;
+		if (!node) return;
 
-                const observer = new IntersectionObserver((entries) => {
-                        const entry = entries[0];
+		const observer = new IntersectionObserver((entries) => {
+			const entry = entries[0];
 
-                        if (!entry?.isIntersecting) return;
+			if (!entry?.isIntersecting) return;
 
-                        if (hasNextPage && !isFetchingNextPage) {
-                                void fetchNextPage();
-                        }
-                });
+			if (hasNextPage && !isFetchingNextPage) {
+				void fetchNextPage();
+			}
+		});
 
-                observer.observe(node);
+		observer.observe(node);
 
-                return () => observer.disconnect();
-        }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+		return () => observer.disconnect();
+	}, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
-        const renderDataDialog = (data: unknown, id: number) => {
-                if (data == null) {
-                        return <span className="text-muted-foreground">-</span>;
-                }
+	const renderDataDialog = (data: unknown, id: number) => {
+		if (data == null) {
+			return <span className="text-muted-foreground">-</span>;
+		}
 
-                return (
-                        <Dialog>
-                                <DialogTrigger asChild>
-                                        <Button variant="ghost" size="sm">
-                                                View
-                                        </Button>
-                                </DialogTrigger>
-                                <DialogContent className="max-w-2xl">
-                                        <DialogHeader>
-                                                <DialogTitle>Log data</DialogTitle>
-                                                <DialogDescription>
-                                                        Payload associated with worker log #{id}.
-                                                </DialogDescription>
-                                        </DialogHeader>
-                                        <pre className="mt-4 max-h-80 overflow-auto rounded bg-muted p-4 text-xs">
-                                                {JSON.stringify(data, null, 2)}
-                                        </pre>
-                                </DialogContent>
-                        </Dialog>
-                );
-        };
+		return (
+			<Dialog>
+				<DialogTrigger asChild>
+					<Button variant="ghost" size="sm">
+						View
+					</Button>
+				</DialogTrigger>
+				<DialogContent className="max-w-2xl">
+					<DialogHeader>
+						<DialogTitle>Log data</DialogTitle>
+						<DialogDescription>
+							Payload associated with worker log #{id}.
+						</DialogDescription>
+					</DialogHeader>
+					<pre className="mt-4 max-h-80 overflow-auto rounded bg-muted p-4 text-xs">
+						{JSON.stringify(data, null, 2)}
+					</pre>
+				</DialogContent>
+			</Dialog>
+		);
+	};
 
-        return (
-                <AppShell
-                        breadcrumbs={[
-                                { label: "Admin", href: "/admin/overview" },
-                                { label: "Logs", current: true },
-                        ]}
-                        headerRight={<UserAvatar />}
-                >
-                        <RedirectToSignIn />
-                        <Card>
-                                <CardHeader className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
-                                        <div>
-                                                <CardTitle>Worker logs</CardTitle>
-                                                <CardDescription>
-                                                        Monitor worker sessions in real time with streaming updates.
-                                                </CardDescription>
-                                        </div>
-                                        <div className="flex flex-wrap items-end gap-4">
-                                                <div className="flex w-52 flex-col gap-2">
-                                                        <Label htmlFor="provider-filter">Provider</Label>
-                                                        {providerQuery.isLoading ? (
-                                                                <Skeleton className="h-10 w-full" />
-                                                        ) : (
-                                                                <Select
-                                                                        value={providerFilter ?? "all"}
-                                                                        onValueChange={(value) =>
-                                                                                setProviderFilter(value === "all" ? null : value)
-                                                                        }
-                                                                >
-                                                                        <SelectTrigger id="provider-filter">
-                                                                                <SelectValue placeholder="All providers" />
-                                                                        </SelectTrigger>
-                                                                        <SelectContent>
-                                                                                <SelectItem value="all">All providers</SelectItem>
-                                                                                {providerQuery.data?.map((provider) => (
-                                                                                        <SelectItem key={provider.id} value={provider.id}>
-                                                                                                {provider.name}
-                                                                                        </SelectItem>
-                                                                                ))}
-                                                                        </SelectContent>
-                                                                </Select>
-                                                        )}
-                                                </div>
-                                                <div className="flex w-52 flex-col gap-2">
-                                                        <Label htmlFor="level-filter">Level</Label>
-                                                        <Select
-                                                                value={levelFilter ?? "all"}
-                                                                onValueChange={(value) =>
-                                                                        setLevelFilter(value === "all" ? null : value)
-                                                                }
-                                                        >
-                                                                <SelectTrigger id="level-filter">
-                                                                        <SelectValue placeholder="All levels" />
-                                                                </SelectTrigger>
-                                                                <SelectContent>
-                                                                        <SelectItem value="all">All levels</SelectItem>
-                                                                        {LOG_LEVELS.map((option) => (
-                                                                                <SelectItem key={option.value} value={option.value}>
-                                                                                        {option.label}
-                                                                                </SelectItem>
-                                                                        ))}
-                                                                </SelectContent>
-                                                        </Select>
-                                                </div>
-                                        </div>
-                                </CardHeader>
-                                <CardContent>
-                                        {logsQuery.isError ? (
-                                                <Alert variant="destructive">
-                                                        <AlertTitle>Unable to load logs</AlertTitle>
-                                                        <AlertDescription>
-                                                                {logsQuery.error instanceof Error
-                                                                        ? logsQuery.error.message
-                                                                        : "Something went wrong while fetching logs."}
-                                                        </AlertDescription>
-                                                </Alert>
-                                        ) : logsQuery.isLoading ? (
-                                                <div className="space-y-3">
-                                                        {[0, 1, 2, 3, 4].map((index) => (
-                                                                <Skeleton key={index} className="h-16 w-full" />
-                                                        ))}
-                                                </div>
-                                        ) : rows.length === 0 ? (
-                                                <Alert>
-                                                        <AlertTitle>No logs yet</AlertTitle>
-                                                        <AlertDescription>
-                                                                Worker output will appear here as soon as new jobs run.
-                                                        </AlertDescription>
-                                                </Alert>
-                                        ) : (
-                                                <div className="space-y-4">
-                                                        <Table>
-                                                                <TableHeader>
-                                                                        <TableRow>
-                                                                                <TableHead className="w-48">Timestamp</TableHead>
-                                                                                <TableHead className="w-44">Provider</TableHead>
-                                                                                <TableHead className="w-40">Session</TableHead>
-                                                                                <TableHead className="w-28">Level</TableHead>
-                                                                                <TableHead>Message</TableHead>
-                                                                                <TableHead className="w-28">Data</TableHead>
-                                                                        </TableRow>
-                                                                </TableHeader>
-                                                                <TableBody>
-                                                                        {rows.map((row) => (
-                                                                                <TableRow key={row.id}>
-                                                                                        <TableCell className="font-mono text-xs">
-                                                                                                {formatTimestamp(row.ts)}
-                                                                                        </TableCell>
-                                                                                        <TableCell className="text-sm">
-                                                                                                {row.providerId
-                                                                                                        ? providerMap.get(row.providerId) ?? row.providerId
-                                                                                                        : "-"}
-                                                                                        </TableCell>
-                                                                                        <TableCell className="text-sm">
-                                                                                                {row.sessionId ?? "-"}
-                                                                                        </TableCell>
-                                                                                        <TableCell>
-                                                                                                <Badge variant={getLevelBadgeVariant(row.level)}>
-                                                                                                        {row.level.toUpperCase()}
-                                                                                                </Badge>
-                                                                                        </TableCell>
-                                                                                        <TableCell className="text-sm">
-                                                                                                {row.msg}
-                                                                                        </TableCell>
-                                                                                        <TableCell>{renderDataDialog(row.data, row.id)}</TableCell>
-                                                                                </TableRow>
-                                                                        ))}
-                                                                </TableBody>
-                                                        </Table>
-                                                        <div ref={sentinelRef} />
-                                                        {isFetchingNextPage ? (
-                                                                <p className="text-muted-foreground text-sm">
-                                                                        Loading more logs...
-                                                                </p>
-                                                        ) : null}
-                                                        {!hasNextPage && rows.length > 0 ? (
-                                                                <p className="text-muted-foreground text-sm">
-                                                                        You&apos;ve reached the end of the available history.
-                                                                </p>
-                                                        ) : null}
-                                                </div>
-                                        )}
-                                </CardContent>
-                        </Card>
-                </AppShell>
-        );
+	return (
+		<AppShell
+			breadcrumbs={[
+				{ label: "Admin", href: "/admin/overview" },
+				{ label: "Logs", current: true },
+			]}
+			headerRight={<UserAvatar />}
+		>
+			<RedirectToSignIn />
+			<Card>
+				<CardHeader className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+					<div>
+						<CardTitle>Worker logs</CardTitle>
+						<CardDescription>
+							Monitor worker sessions in real time with streaming updates.
+						</CardDescription>
+					</div>
+					<div className="flex flex-wrap items-end gap-4">
+						<div className="flex w-52 flex-col gap-2">
+							<Label htmlFor={providerSelectId}>Provider</Label>
+							{providerQuery.isLoading ? (
+								<Skeleton className="h-10 w-full" />
+							) : (
+								<Select
+									value={providerFilter ?? "all"}
+									onValueChange={(value) =>
+										setProviderFilter(value === "all" ? null : value)
+									}
+								>
+									<SelectTrigger id={providerSelectId}>
+										<SelectValue placeholder="All providers" />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="all">All providers</SelectItem>
+										{providerQuery.data?.map((provider) => (
+											<SelectItem key={provider.id} value={provider.id}>
+												{provider.name}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							)}
+						</div>
+						<div className="flex w-52 flex-col gap-2">
+							<Label htmlFor={levelSelectId}>Level</Label>
+							<Select
+								value={levelFilter ?? "all"}
+								onValueChange={(value) =>
+									setLevelFilter(value === "all" ? null : value)
+								}
+							>
+								<SelectTrigger id={levelSelectId}>
+									<SelectValue placeholder="All levels" />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="all">All levels</SelectItem>
+									{LOG_LEVELS.map((option) => (
+										<SelectItem key={option.value} value={option.value}>
+											{option.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+					</div>
+				</CardHeader>
+				<CardContent>
+					{logsQuery.isError ? (
+						<Alert variant="destructive">
+							<AlertTitle>Unable to load logs</AlertTitle>
+							<AlertDescription>
+								{logsQuery.error instanceof Error
+									? logsQuery.error.message
+									: "Something went wrong while fetching logs."}
+							</AlertDescription>
+						</Alert>
+					) : logsQuery.isLoading ? (
+						<div className="space-y-3">
+							{[0, 1, 2, 3, 4].map((index) => (
+								<Skeleton key={index} className="h-16 w-full" />
+							))}
+						</div>
+					) : rows.length === 0 ? (
+						<Alert>
+							<AlertTitle>No logs yet</AlertTitle>
+							<AlertDescription>
+								Worker output will appear here as soon as new jobs run.
+							</AlertDescription>
+						</Alert>
+					) : (
+						<div className="space-y-4">
+							<Table>
+								<TableHeader>
+									<TableRow>
+										<TableHead className="w-48">Timestamp</TableHead>
+										<TableHead className="w-44">Provider</TableHead>
+										<TableHead className="w-40">Session</TableHead>
+										<TableHead className="w-28">Level</TableHead>
+										<TableHead>Message</TableHead>
+										<TableHead className="w-28">Data</TableHead>
+									</TableRow>
+								</TableHeader>
+								<TableBody>
+									{rows.map((row) => (
+										<TableRow key={row.id}>
+											<TableCell className="font-mono text-xs">
+												{formatTimestamp(row.ts)}
+											</TableCell>
+											<TableCell className="text-sm">
+												{row.providerId
+													? (providerMap.get(row.providerId) ?? row.providerId)
+													: "-"}
+											</TableCell>
+											<TableCell className="text-sm">
+												{row.sessionId ?? "-"}
+											</TableCell>
+											<TableCell>
+												<Badge variant={getLevelBadgeVariant(row.level)}>
+													{row.level.toUpperCase()}
+												</Badge>
+											</TableCell>
+											<TableCell className="text-sm">{row.msg}</TableCell>
+											<TableCell>
+												{renderDataDialog(row.data, row.id)}
+											</TableCell>
+										</TableRow>
+									))}
+								</TableBody>
+							</Table>
+							<div ref={sentinelRef} />
+							{isFetchingNextPage ? (
+								<p className="text-muted-foreground text-sm">
+									Loading more logs...
+								</p>
+							) : null}
+							{!hasNextPage && rows.length > 0 ? (
+								<p className="text-muted-foreground text-sm">
+									You&apos;ve reached the end of the available history.
+								</p>
+							) : null}
+						</div>
+					)}
+				</CardContent>
+			</Card>
+		</AppShell>
+	);
 }

--- a/apps/server/src/hooks/use-admin-logs.test.ts
+++ b/apps/server/src/hooks/use-admin-logs.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import type { InfiniteData } from "@tanstack/react-query";
+
+import {
+	type LogEntry,
+	type LogListResult,
+	mergeLogsIntoPages,
+} from "./use-admin-logs";
+
+function createLog(id: number, overrides: Partial<LogEntry> = {}): LogEntry {
+	const base: LogEntry = {
+		id,
+		ts: new Date(id * 1000),
+		level: "info",
+		providerId: null,
+		sessionId: null,
+		msg: `log-${id}`,
+		data: null,
+	} as LogEntry;
+
+	return {
+		...base,
+		...overrides,
+	};
+}
+
+describe("mergeLogsIntoPages", () => {
+	it("adds logs when no existing pages are cached", () => {
+		const result = mergeLogsIntoPages(undefined, [createLog(1)]);
+
+		expect(result.pages[0]?.logs.map((log) => log.id)).toEqual([1]);
+	});
+
+	it("prepends logs to the first page and removes duplicates from later pages", () => {
+		const existing: InfiniteData<LogListResult> = {
+			pageParams: [undefined],
+			pages: [
+				{
+					logs: [createLog(2)],
+					nextCursor: 123,
+				},
+				{
+					logs: [createLog(3), createLog(1)],
+					nextCursor: null,
+				},
+			],
+		};
+
+		const incoming = [createLog(4), createLog(1)];
+
+		const result = mergeLogsIntoPages(existing, incoming);
+
+		expect(result.pages[0]?.logs.map((log) => log.id)).toEqual([4, 1, 2]);
+		expect(result.pages[1]?.logs.map((log) => log.id)).toEqual([3]);
+	});
+
+	it("ignores duplicate incoming ids while preserving newest-first ordering", () => {
+		const incoming = [createLog(5), createLog(5), createLog(4)];
+		const result = mergeLogsIntoPages(undefined, incoming);
+
+		expect(result.pages[0]?.logs.map((log) => log.id)).toEqual([5, 4]);
+	});
+});


### PR DESCRIPTION
## Summary
- buffer admin log SSE events while the initial query is pending and flush them into the cache once loading completes
- add a reusable helper to merge streamed entries with cached pages and ensure filter controls use unique ids
- cover the merge behaviour with unit tests to guard against regressions when events arrive before the first page load

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_b_68d2c242cb8c83278dbbae34b02c7b93