### PR TITLE
feat(server): add events admin router

### DIFF
--- a/apps/server/src/routers/index.ts
+++ b/apps/server/src/routers/index.ts
@@ -2,6 +2,7 @@ import { protectedProcedure, publicProcedure, router } from "../lib/trpc";
 import { adminFlagsRouter } from "./admin-flags";
 import { adminLogsRouter } from "./admin-logs";
 import { adminUsersRouter } from "./admin-users";
+import { eventsRouter } from "./events";
 import { providersRouter } from "./providers";
 
 export const appRouter = router({
@@ -15,6 +16,7 @@ export const appRouter = router({
 		};
 	}),
 	providers: providersRouter,
+	events: eventsRouter,
 	adminUsers: adminUsersRouter,
 	adminFlags: adminFlagsRouter,
 	adminLogs: adminLogsRouter,


### PR DESCRIPTION
## Summary
- add an admin-only `eventsRouter` that covers listing, retrieval, mutations, bulk status updates, and stats with Zod validation
- implement cursor-based pagination, filter helpers, and Drizzle queries for event records
- register the events router on the main `appRouter` for client access

## Testing
- bunx biome check apps/server/src/routers/events.ts apps/server/src/routers/index.ts

------
https://chatgpt.com/codex/tasks/task_b_68d3d376b4688327a3c2532fd0f9c8f8