### PR TITLE
Document admin events moderation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ bun install
 ## Monitoring worker activity
 
 Administrators can open [`/admin/logs`](apps/server/src/app/(site)/admin/logs/page.tsx) in the admin console to watch worker sessions in real time. The page keeps a live Server-Sent Events (SSE) subscription open to the server, streams new rows from the `worker_log` table into the UI, and augments them with history fetched through tRPC. The SSE channel is strictly one-way for monitoring purposes—no writes or admin actions are performed over the stream.
+
+## Moderating synchronized events
+
+The event moderation workspace lives at [`/admin/events`](apps/server/src/app/(site)/admin/events/page.tsx). You must be signed in with an account that has the `admin` role to access it—non-admin users are redirected away by the admin layout guard. Once authenticated, the "Events" item appears in the admin navigation alongside the other moderation tools.
+
+The page is designed for high-volume review and offers several tools that work together:
+
+- **Filter controls** – Search across titles, descriptions, and locations, filter by event status, provider, start date range, publication or all-day flags, and constrain the acceptable priority range. Filters sync to the URL, persist to local storage, and refresh the event list as you adjust them.
+- **View switcher** – Toggle between a compact table and card-based layout using the buttons in the header, depending on whether you need a dense overview or richer context for each event.
+- **Infinite pagination** – Scroll to the end of the list to load more results. An intersection observer watches the sentinel at the bottom of the page and automatically requests additional pages when needed.
+- **Bulk moderation actions** – Select individual rows or cards (or use the header checkbox to select all on the current page) to activate the bulk action bar, then apply the predefined status transitions such as approve, mark pending, or archive to every selected event at once.
+
+Open the drawer or dialog actions in each row/card to see the complete metadata, update individual events, or inspect detailed timing, provider, and flag information before applying changes.
 ## Database Setup
 
 This project uses PostgreSQL with Drizzle ORM.


### PR DESCRIPTION
## Summary
- document prerequisites for reaching the admin events moderation page
- explain filters, view switching, pagination, and bulk actions available to administrators

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d3e0c87cd8832790bdcaa6a7a0e2cc