### PR TITLE
Refactor admin events list view into shared components

### DIFF
--- a/apps/server/src/components/admin/events/EventActionsMenu.tsx
+++ b/apps/server/src/components/admin/events/EventActionsMenu.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { MoreHorizontal } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+import type { StatusAction } from "./status-actions";
+
+type EventActionsMenuProps = {
+	statusActions: StatusAction[];
+	onUpdateStatus: (status: StatusAction["status"]) => void;
+	onEdit: () => void;
+	onView: () => void;
+	disabled?: boolean;
+};
+
+export function EventActionsMenu({
+	statusActions,
+	onUpdateStatus,
+	onEdit,
+	onView,
+	disabled = false,
+}: EventActionsMenuProps) {
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button variant="ghost" size="icon" disabled={disabled}>
+					<MoreHorizontal className="size-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" className="w-48">
+				<DropdownMenuLabel>Moderation</DropdownMenuLabel>
+				{statusActions.map((action) => (
+					<DropdownMenuItem
+						key={action.status}
+						onClick={() => onUpdateStatus(action.status)}
+					>
+						<action.icon className="mr-2 size-4" />
+						{action.label}
+					</DropdownMenuItem>
+				))}
+				<DropdownMenuSeparator />
+				<DropdownMenuItem onClick={onEdit}>Edit event</DropdownMenuItem>
+				<DropdownMenuItem onClick={onView}>View details</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/server/src/components/admin/events/EventListView.tsx
+++ b/apps/server/src/components/admin/events/EventListView.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { CalendarDays, ExternalLink, Tag } from "lucide-react";
+import { statusOptionMap } from "@/app/(site)/admin/events/event-filters";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+
+import { EventActionsMenu } from "./EventActionsMenu";
+import { EventPreview } from "./EventPreview";
+import { statusActions } from "./status-actions";
+import type { EventListItem } from "./types";
+
+export type EventListViewProps = {
+	events: EventListItem[];
+	view: "table" | "card";
+	selectedIds: string[];
+	onSelect: (id: string, checked: boolean) => void;
+	onSelectAll: (checked: boolean) => void;
+	onEdit: (event: EventListItem) => void;
+	onViewDetail: (id: string) => void;
+	onStatusAction: (id: string, status: EventListItem["status"]) => void;
+};
+
+export function EventListView({
+	events,
+	view,
+	selectedIds,
+	onSelect,
+	onSelectAll,
+	onEdit,
+	onViewDetail,
+	onStatusAction,
+}: EventListViewProps) {
+	const selectedIdSet = new Set(selectedIds);
+	const allSelectedOnPage =
+		events.length > 0 && events.every((event) => selectedIdSet.has(event.id));
+	const headerCheckboxState = selectedIds.length
+		? allSelectedOnPage
+			? true
+			: "indeterminate"
+		: false;
+
+	if (view === "card") {
+		return (
+			<div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+				{events.map((event) => {
+					const isSelected = selectedIdSet.has(event.id);
+					return (
+						<Card
+							key={event.id}
+							className={cn(
+								"relative flex h-full flex-col border",
+								isSelected &&
+									"border-primary/60 shadow-[0_0_0_1px_rgba(59,130,246,0.4)]",
+							)}
+						>
+							<CardHeader className="space-y-3">
+								<div className="flex items-start justify-between gap-3">
+									<EventPreview
+										event={event}
+										layout="card"
+										inlineTitle={false}
+										badgePrefix={
+											<>
+												<Checkbox
+													checked={isSelected}
+													onCheckedChange={(checked) =>
+														onSelect(event.id, Boolean(checked))
+													}
+													aria-label={`Select event ${event.title}`}
+												/>
+												<Badge
+													variant={statusOptionMap[event.status].badgeVariant}
+												>
+													{statusOptionMap[event.status].label}
+												</Badge>
+											</>
+										}
+										titleSlot={
+											<CardTitle className="line-clamp-2 break-words text-xl leading-tight">
+												{event.title}
+											</CardTitle>
+										}
+									/>
+									<EventActionsMenu
+										statusActions={statusActions}
+										onUpdateStatus={(status) =>
+											onStatusAction(event.id, status)
+										}
+										onEdit={() => onEdit(event)}
+										onView={() => onViewDetail(event.id)}
+									/>
+								</div>
+							</CardHeader>
+							<CardContent className="flex flex-1 flex-col gap-4">
+								<div className="flex flex-wrap gap-2 text-muted-foreground text-xs sm:text-sm">
+									<span className="flex items-center gap-2 rounded-md border bg-muted/60 px-2 py-1">
+										<Tag className="size-4" />
+										Priority {event.priority}
+									</span>
+									<span className="flex items-center gap-2 rounded-md border bg-muted/60 px-2 py-1 text-muted-foreground">
+										<ExternalLink className="size-4" />
+										{event.isPublished ? "Published" : "Draft"}
+									</span>
+								</div>
+								<div className="space-y-2 text-sm">
+									<p className="flex min-w-0 flex-wrap items-center gap-2 text-muted-foreground">
+										<CalendarDays className="size-4 shrink-0" />
+										<span className="min-w-0 break-words">
+											Provider: {event.provider?.name ?? "Unassigned"}
+											{event.provider?.category
+												? ` • ${event.provider.category}`
+												: ""}
+										</span>
+									</p>
+									{event.flag ? (
+										<p className="flex items-center gap-2 text-muted-foreground">
+											<Tag className="size-4" />
+											Flagged: {event.flag.label}
+										</p>
+									) : null}
+								</div>
+							</CardContent>
+						</Card>
+					);
+				})}
+			</div>
+		);
+	}
+
+	return (
+		<div className="overflow-hidden rounded-lg border">
+			<Table>
+				<TableHeader className="bg-muted/40">
+					<TableRow>
+						<TableHead className="w-12">
+							<Checkbox
+								checked={headerCheckboxState}
+								onCheckedChange={(checked) => onSelectAll(Boolean(checked))}
+								aria-label="Select all events"
+							/>
+						</TableHead>
+						<TableHead className="min-w-[260px]">Event</TableHead>
+						<TableHead>Provider</TableHead>
+						<TableHead>Status</TableHead>
+						<TableHead>Priority</TableHead>
+						<TableHead>Published</TableHead>
+						<TableHead className="text-right">Actions</TableHead>
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{events.map((event) => {
+						const isSelected = selectedIdSet.has(event.id);
+						return (
+							<TableRow key={event.id} className="align-top">
+								<TableCell>
+									<Checkbox
+										checked={isSelected}
+										onCheckedChange={(checked) =>
+											onSelect(event.id, Boolean(checked))
+										}
+										aria-label={`Select event ${event.title}`}
+									/>
+								</TableCell>
+								<TableCell className="max-w-[420px]">
+									<EventPreview event={event} />
+								</TableCell>
+								<TableCell>
+									<div className="flex flex-col">
+										<span className="font-medium text-sm">
+											{event.provider?.name ?? "Unassigned"}
+										</span>
+										{event.provider?.category ? (
+											<span className="text-muted-foreground text-xs">
+												{event.provider.category}
+											</span>
+										) : null}
+									</div>
+								</TableCell>
+								<TableCell>
+									<Badge variant={statusOptionMap[event.status].badgeVariant}>
+										{statusOptionMap[event.status].label}
+									</Badge>
+								</TableCell>
+								<TableCell>
+									<Badge variant="outline">{event.priority}</Badge>
+								</TableCell>
+								<TableCell>
+									<Badge variant={event.isPublished ? "default" : "outline"}>
+										{event.isPublished ? "Published" : "Draft"}
+									</Badge>
+								</TableCell>
+								<TableCell className="text-right">
+									<EventActionsMenu
+										statusActions={statusActions}
+										onUpdateStatus={(status) =>
+											onStatusAction(event.id, status)
+										}
+										onEdit={() => onEdit(event)}
+										onView={() => onViewDetail(event.id)}
+									/>
+								</TableCell>
+							</TableRow>
+						);
+					})}
+				</TableBody>
+			</Table>
+		</div>
+	);
+}

--- a/apps/server/src/components/admin/events/EventPreview.tsx
+++ b/apps/server/src/components/admin/events/EventPreview.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { CalendarClock, Clock, MapPin, Tag } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { CardDescription } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import type { EventListItem } from "./types";
+import { formatDisplayDate } from "./utils";
+
+type EventPreviewProps = {
+	event: EventListItem;
+	layout?: "table" | "card";
+	className?: string;
+	titleSlot?: ReactNode;
+	inlineTitle?: boolean;
+	badgePrefix?: ReactNode;
+};
+
+export function EventPreview({
+	event,
+	layout = "table",
+	className,
+	titleSlot,
+	inlineTitle = true,
+	badgePrefix,
+}: EventPreviewProps) {
+	const containerClasses =
+		layout === "card" ? "flex flex-col gap-3" : "flex flex-col gap-2";
+	const scheduleClasses =
+		layout === "card"
+			? "space-y-1 text-muted-foreground text-sm"
+			: "flex flex-col gap-1 text-muted-foreground text-xs leading-5";
+	const locationClasses =
+		layout === "card"
+			? "flex min-w-0 flex-wrap items-center gap-2 text-muted-foreground text-sm"
+			: "flex min-w-0 flex-wrap items-center gap-1 text-muted-foreground text-xs leading-tight";
+	const iconClasses = layout === "card" ? "size-4 shrink-0" : "size-3 shrink-0";
+	const badgeIconClasses = "size-3";
+	const badgeRowClasses = "flex flex-wrap items-center gap-2";
+	const titleContent = titleSlot ?? (
+		<span className="line-clamp-2 break-words font-medium text-sm leading-tight sm:text-base">
+			{event.title}
+		</span>
+	);
+	const locationText =
+		layout === "card"
+			? (event.location ?? "No location")
+			: (event.location ?? "");
+	const shouldRenderBadges =
+		Boolean(badgePrefix) ||
+		inlineTitle ||
+		event.isAllDay ||
+		Boolean(event.flag);
+
+	return (
+		<div className={cn(containerClasses, className)}>
+			{titleSlot && !inlineTitle ? titleSlot : null}
+			{shouldRenderBadges ? (
+				<div className={badgeRowClasses}>
+					{badgePrefix}
+					{inlineTitle ? titleContent : null}
+					{event.isAllDay ? (
+						<Badge variant="outline" className="uppercase">
+							All-day
+						</Badge>
+					) : null}
+					{event.flag ? (
+						<Badge variant="secondary" className="gap-1">
+							<Tag className={badgeIconClasses} />
+							<span className="min-w-0 break-words">{event.flag.label}</span>
+						</Badge>
+					) : null}
+				</div>
+			) : null}
+			{!inlineTitle && !titleSlot ? titleContent : null}
+			{event.description ? (
+				layout === "card" ? (
+					<CardDescription className="line-clamp-3 break-words text-sm leading-snug">
+						{event.description}
+					</CardDescription>
+				) : (
+					<p className="line-clamp-2 break-words text-muted-foreground text-sm leading-snug">
+						{event.description}
+					</p>
+				)
+			) : null}
+			<div className={scheduleClasses}>
+				<span className="flex min-w-0 flex-wrap items-center gap-1">
+					<CalendarClock className={iconClasses} />
+					<span className="min-w-0 break-words">
+						{formatDisplayDate(event.startAt)}
+					</span>
+				</span>
+				{event.endAt ? (
+					<span className="flex min-w-0 flex-wrap items-center gap-1">
+						<Clock className={iconClasses} />
+						<span className="min-w-0 break-words">
+							{formatDisplayDate(event.endAt)}
+						</span>
+					</span>
+				) : null}
+			</div>
+			{locationText ? (
+				<p className={locationClasses}>
+					<MapPin className={iconClasses} />
+					<span className="line-clamp-2 min-w-0 break-words">
+						{locationText}
+					</span>
+				</p>
+			) : null}
+		</div>
+	);
+}

--- a/apps/server/src/components/admin/events/status-actions.ts
+++ b/apps/server/src/components/admin/events/status-actions.ts
@@ -1,0 +1,16 @@
+import { RefreshCcw, UserCheck, UserX } from "lucide-react";
+import type { ComponentType, SVGProps } from "react";
+
+import type { EventStatus } from "@/app/(site)/admin/events/event-filters";
+
+export type StatusAction = {
+	label: string;
+	status: EventStatus;
+	icon: ComponentType<SVGProps<SVGSVGElement>>;
+};
+
+export const statusActions: StatusAction[] = [
+	{ label: "Validate", status: "approved", icon: UserCheck },
+	{ label: "Mark pending", status: "pending", icon: RefreshCcw },
+	{ label: "Archive", status: "rejected", icon: UserX },
+];

--- a/apps/server/src/components/admin/events/types.ts
+++ b/apps/server/src/components/admin/events/types.ts
@@ -1,0 +1,6 @@
+import type { inferRouterOutputs } from "@trpc/server";
+
+import type { AppRouter } from "@/routers";
+
+export type EventsListOutput = inferRouterOutputs<AppRouter>["events"]["list"];
+export type EventListItem = EventsListOutput["items"][number];

--- a/apps/server/src/components/admin/events/utils.ts
+++ b/apps/server/src/components/admin/events/utils.ts
@@ -1,0 +1,8 @@
+import { format } from "date-fns";
+
+export function formatDisplayDate(value: string | Date | null | undefined) {
+	if (!value) return "";
+	const date = value instanceof Date ? value : new Date(value);
+	if (Number.isNaN(date.getTime())) return "";
+	return format(date, "MMM d, yyyy p");
+}


### PR DESCRIPTION
## Summary
- extract shared event preview and actions menu components for admin events
- add an EventListView component that reuses the shared pieces for table and card layouts
- refactor the admin events page to rely on the new list view and shared status action definitions

## Testing
- bun run check *(fails: Biome reports existing lint/config issues across the repo)*

------
https://chatgpt.com/codex/tasks/task_b_68d4ebfdf6508327a401b53239eceb8f