### PR TITLE
Refactor admin events detail and edit UI into reusable components

### DIFF
--- a/apps/server/src/components/admin/events/EventDetailSheet.tsx
+++ b/apps/server/src/components/admin/events/EventDetailSheet.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+        Sheet,
+        SheetContent,
+        SheetDescription,
+        SheetHeader,
+        SheetTitle,
+} from "@/components/ui/sheet";
+import type { EventStatus } from "@/app/(site)/admin/events/event-filters";
+import { statusOptionMap } from "@/app/(site)/admin/events/event-filters";
+import type { StatusAction } from "./status-actions";
+import type { EventListItem } from "./types";
+import { formatDisplayDate } from "@/lib/datetime";
+
+type EventDetailSheetProps = {
+        event: EventListItem | null;
+        statusActions: StatusAction[];
+        onUpdateStatus: (eventId: string, status: EventStatus) => void;
+        onEdit: (event: EventListItem) => void;
+        onClose: () => void;
+        statusLoading: boolean;
+};
+
+export function EventDetailSheet({
+        event,
+        statusActions,
+        onUpdateStatus,
+        onEdit,
+        onClose,
+        statusLoading,
+}: EventDetailSheetProps) {
+        return (
+                <Sheet
+                        open={event != null}
+                        onOpenChange={(open) => {
+                                if (!open) onClose();
+                        }}
+                >
+                        <SheetContent side="right" className="min-w-2xl max-w-2xl overflow-y-auto p-3">
+                                <SheetHeader>
+                                        <SheetTitle>{event?.title ?? "Event details"}</SheetTitle>
+                                        <SheetDescription>
+                                                Review the synchronized metadata before applying moderation changes.
+                                        </SheetDescription>
+                                </SheetHeader>
+                                {event ? (
+                                        <div className="mt-6 space-y-6">
+                                                <div className="space-y-2">
+                                                        <p className="text-muted-foreground text-sm">Event ID: {event.id}</p>
+                                                        {event.externalId ? (
+                                                                <p className="text-muted-foreground text-sm">
+                                                                        External ID: {event.externalId}
+                                                                </p>
+                                                        ) : null}
+                                                        <div className="flex flex-wrap gap-2">
+                                                                <Badge variant={statusOptionMap[event.status].badgeVariant}>
+                                                                        {statusOptionMap[event.status].label}
+                                                                </Badge>
+                                                                <Badge variant={event.isPublished ? "default" : "outline"}>
+                                                                        {event.isPublished ? "Published" : "Draft"}
+                                                                </Badge>
+                                                                {event.isAllDay ? <Badge variant="outline">All-day</Badge> : null}
+                                                        </div>
+                                                </div>
+                                                <div className="space-y-1 text-sm">
+                                                        <p className="font-semibold text-foreground">Schedule</p>
+                                                        <p className="text-muted-foreground">
+                                                                Starts: {formatDisplayDate(event.startAt)}
+                                                        </p>
+                                                        {event.endAt ? (
+                                                                <p className="text-muted-foreground">
+                                                                        Ends: {formatDisplayDate(event.endAt)}
+                                                                </p>
+                                                        ) : null}
+                                                </div>
+                                                <div className="space-y-1 text-sm">
+                                                        <p className="font-semibold text-foreground">Location</p>
+                                                        <p className="text-muted-foreground">
+                                                                {event.location ?? "No location provided"}
+                                                        </p>
+                                                </div>
+                                                <div className="space-y-1 text-sm">
+                                                        <p className="font-semibold text-foreground">Provider</p>
+                                                        <p className="text-muted-foreground">
+                                                                {event.provider?.name ?? "Unassigned"}
+                                                        </p>
+                                                        {event.provider?.category ? (
+                                                                <p className="text-muted-foreground">{event.provider.category}</p>
+                                                        ) : null}
+                                                </div>
+                                                {event.description ? (
+                                                        <div className="space-y-1 text-sm">
+                                                                <p className="font-semibold text-foreground">Description</p>
+                                                                <p className="whitespace-pre-wrap text-muted-foreground">
+                                                                        {event.description}
+                                                                </p>
+                                                        </div>
+                                                ) : null}
+                                                <div className="space-y-1 text-sm">
+                                                        <p className="font-semibold text-foreground">Metadata</p>
+                                                        <pre className="max-h-48 overflow-auto rounded-md bg-muted/60 p-3 text-xs">
+                                                                {JSON.stringify(event.metadata ?? {}, null, 2)}
+                                                        </pre>
+                                                </div>
+                                                <div className="flex flex-wrap gap-2">
+                                                        {statusActions.map((action) => (
+                                                                <Button
+                                                                        key={action.status}
+                                                                        onClick={() => onUpdateStatus(event.id, action.status)}
+                                                                        disabled={statusLoading}
+                                                                >
+                                                                        <action.icon className="mr-2 size-4" />
+                                                                        {action.label}
+                                                                </Button>
+                                                        ))}
+                                                        <Button variant="outline" onClick={() => onEdit(event)}>
+                                                                Edit event
+                                                        </Button>
+                                                </div>
+                                        </div>
+                                ) : null}
+                        </SheetContent>
+                </Sheet>
+        );
+}

--- a/apps/server/src/components/admin/events/EventEditDialog.tsx
+++ b/apps/server/src/components/admin/events/EventEditDialog.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+        Dialog,
+        DialogContent,
+        DialogDescription,
+        DialogFooter,
+        DialogHeader,
+        DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+        Select,
+        SelectContent,
+        SelectItem,
+        SelectTrigger,
+        SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import type { EventListItem } from "./types";
+import { formatDateTimeLocal } from "@/lib/datetime";
+
+export type EventEditFormValues = {
+        title: string;
+        description: string;
+        location: string;
+        url: string;
+        startAt: string;
+        endAt: string;
+        isAllDay: boolean;
+        isPublished: boolean;
+        externalId: string;
+        priority: number;
+        providerId: string;
+};
+
+export type ProviderOption = {
+        id: string;
+        name: string;
+};
+
+type EventEditDialogProps = {
+        open: boolean;
+        event: EventListItem | null;
+        providers: ProviderOption[];
+        onSubmit: (values: EventEditFormValues) => void;
+        onClose: () => void;
+        isSaving: boolean;
+};
+
+const defaultValues: EventEditFormValues = {
+        title: "",
+        description: "",
+        location: "",
+        url: "",
+        startAt: "",
+        endAt: "",
+        isAllDay: false,
+        isPublished: false,
+        externalId: "",
+        priority: 3,
+        providerId: "",
+};
+
+export function EventEditDialog({
+        open,
+        event,
+        providers,
+        onSubmit,
+        onClose,
+        isSaving,
+}: EventEditDialogProps) {
+        const [values, setValues] = useState<EventEditFormValues>({ ...defaultValues });
+
+        useEffect(() => {
+                if (!event || !open) {
+                        setValues({ ...defaultValues });
+                        return;
+                }
+
+                setValues({
+                        title: event.title,
+                        description: event.description ?? "",
+                        location: event.location ?? "",
+                        url: event.url ?? "",
+                        startAt: formatDateTimeLocal(event.startAt),
+                        endAt: formatDateTimeLocal(event.endAt),
+                        isAllDay: event.isAllDay,
+                        isPublished: event.isPublished,
+                        externalId: event.externalId ?? "",
+                        priority: event.priority,
+                        providerId: event.provider?.id ?? "",
+                });
+        }, [event, open]);
+
+        return (
+                <Dialog
+                        open={open}
+                        onOpenChange={(nextOpen) => {
+                                if (!nextOpen) onClose();
+                        }}
+                >
+                        <DialogContent className="sm:max-w-lg">
+                                <form
+                                        onSubmit={(formEvent) => {
+                                                formEvent.preventDefault();
+                                                if (!event) return;
+                                                onSubmit(values);
+                                        }}
+                                        className="space-y-4"
+                                >
+                                        <DialogHeader>
+                                                <DialogTitle>Edit event</DialogTitle>
+                                                <DialogDescription>
+                                                        Update key event metadata before saving your moderation changes.
+                                                </DialogDescription>
+                                        </DialogHeader>
+                                        <div className="space-y-2">
+                                                <Label htmlFor="event-title">Title</Label>
+                                                <Input
+                                                        id="event-title"
+                                                        value={values.title}
+                                                        onChange={(changeEvent) =>
+                                                                setValues((prev) => ({
+                                                                        ...prev,
+                                                                        title: changeEvent.target.value,
+                                                                }))
+                                                        }
+                                                        required
+                                                />
+                                        </div>
+                                        <div className="space-y-2">
+                                                <Label htmlFor="event-description">Description</Label>
+                                                <textarea
+                                                        id="event-description"
+                                                        value={values.description}
+                                                        onChange={(changeEvent) =>
+                                                                setValues((prev) => ({
+                                                                        ...prev,
+                                                                        description: changeEvent.target.value,
+                                                                }))
+                                                        }
+                                                        className="min-h-[96px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                                                />
+                                        </div>
+                                        <div className="grid gap-4 sm:grid-cols-2">
+                                                <div className="space-y-2">
+                                                        <Label htmlFor="event-start">Start time</Label>
+                                                        <Input
+                                                                id="event-start"
+                                                                type="datetime-local"
+                                                                value={values.startAt}
+                                                                onChange={(changeEvent) =>
+                                                                        setValues((prev) => ({
+                                                                                ...prev,
+                                                                                startAt: changeEvent.target.value,
+                                                                        }))
+                                                                }
+                                                        />
+                                                </div>
+                                                <div className="space-y-2">
+                                                        <Label htmlFor="event-end">End time</Label>
+                                                        <Input
+                                                                id="event-end"
+                                                                type="datetime-local"
+                                                                value={values.endAt}
+                                                                onChange={(changeEvent) =>
+                                                                        setValues((prev) => ({
+                                                                                ...prev,
+                                                                                endAt: changeEvent.target.value,
+                                                                        }))
+                                                                }
+                                                        />
+                                                </div>
+                                        </div>
+                                        <div className="grid gap-4 sm:grid-cols-2">
+                                                <div className="space-y-2">
+                                                        <Label htmlFor="event-location">Location</Label>
+                                                        <Input
+                                                                id="event-location"
+                                                                value={values.location}
+                                                                onChange={(changeEvent) =>
+                                                                        setValues((prev) => ({
+                                                                                ...prev,
+                                                                                location: changeEvent.target.value,
+                                                                        }))
+                                                                }
+                                                        />
+                                                </div>
+                                                <div className="space-y-2">
+                                                        <Label htmlFor="event-url">URL</Label>
+                                                        <Input
+                                                                id="event-url"
+                                                                value={values.url}
+                                                                onChange={(changeEvent) =>
+                                                                        setValues((prev) => ({
+                                                                                ...prev,
+                                                                                url: changeEvent.target.value,
+                                                                        }))
+                                                                }
+                                                        />
+                                                </div>
+                                        </div>
+                                        <div className="grid gap-4 sm:grid-cols-2">
+                                                <div className="space-y-2">
+                                                        <Label htmlFor="event-priority">Priority</Label>
+                                                        <Select
+                                                                value={String(values.priority)}
+                                                                onValueChange={(value) =>
+                                                                        setValues((prev) => ({
+                                                                                ...prev,
+                                                                                priority: Number(value),
+                                                                        }))
+                                                                }
+                                                        >
+                                                                <SelectTrigger id="event-priority">
+                                                                        <SelectValue placeholder="Priority" />
+                                                                </SelectTrigger>
+                                                                <SelectContent>
+                                                                        {[1, 2, 3, 4, 5].map((priority) => (
+                                                                                <SelectItem key={priority} value={String(priority)}>
+                                                                                        {priority}
+                                                                                </SelectItem>
+                                                                        ))}
+                                                                </SelectContent>
+                                                        </Select>
+                                                </div>
+                                                <div className="space-y-2">
+                                                        <Label htmlFor="event-provider">Provider</Label>
+                                                        <Select
+                                                                value={values.providerId}
+                                                                onValueChange={(value) =>
+                                                                        setValues((prev) => ({
+                                                                                ...prev,
+                                                                                providerId: value,
+                                                                        }))
+                                                                }
+                                                        >
+                                                                <SelectTrigger id="event-provider">
+                                                                        <SelectValue placeholder="Select provider" />
+                                                                </SelectTrigger>
+                                                                <SelectContent>
+                                                                        <SelectItem value="">Unassigned</SelectItem>
+                                                                        {providers.map((provider) => (
+                                                                                <SelectItem key={provider.id} value={provider.id}>
+                                                                                        {provider.name}
+                                                                                </SelectItem>
+                                                                        ))}
+                                                                </SelectContent>
+                                                        </Select>
+                                                </div>
+                                        </div>
+                                        <div className="grid gap-4 sm:grid-cols-2">
+                                                <div className="space-y-2">
+                                                        <Label htmlFor="event-external">External ID</Label>
+                                                        <Input
+                                                                id="event-external"
+                                                                value={values.externalId}
+                                                                onChange={(changeEvent) =>
+                                                                        setValues((prev) => ({
+                                                                                ...prev,
+                                                                                externalId: changeEvent.target.value,
+                                                                        }))
+                                                                }
+                                                        />
+                                                </div>
+                                                <div className="flex items-center justify-between gap-3 rounded-md border bg-muted/40 px-3 py-2">
+                                                        <div>
+                                                                <Label htmlFor="event-published" className="font-medium text-sm">
+                                                                        Published
+                                                                </Label>
+                                                                <p className="text-muted-foreground text-xs">
+                                                                        Toggle whether the event is visible externally.
+                                                                </p>
+                                                        </div>
+                                                        <Switch
+                                                                id="event-published"
+                                                                checked={values.isPublished}
+                                                                onCheckedChange={(checked) =>
+                                                                        setValues((prev) => ({
+                                                                                ...prev,
+                                                                                isPublished: checked,
+                                                                        }))
+                                                                }
+                                                        />
+                                                </div>
+                                        </div>
+                                        <div className="flex items-center justify-between gap-3 rounded-md border bg-muted/40 px-3 py-2">
+                                                <div>
+                                                        <Label htmlFor="event-allday" className="font-medium text-sm">
+                                                                All-day event
+                                                        </Label>
+                                                        <p className="text-muted-foreground text-xs">
+                                                                Set to true if this event spans the entire day.
+                                                        </p>
+                                                </div>
+                                                <Switch
+                                                        id="event-allday"
+                                                        checked={values.isAllDay}
+                                                        onCheckedChange={(checked) =>
+                                                                setValues((prev) => ({
+                                                                        ...prev,
+                                                                        isAllDay: checked,
+                                                                }))
+                                                        }
+                                                />
+                                        </div>
+                                        <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+                                                <Button type="button" variant="outline" onClick={onClose}>
+                                                        Cancel
+                                                </Button>
+                                                <Button type="submit" disabled={isSaving}>
+                                                        {isSaving ? "Saving…" : "Save changes"}
+                                                </Button>
+                                        </DialogFooter>
+                                </form>
+                        </DialogContent>
+                </Dialog>
+        );
+}

--- a/apps/server/src/components/admin/events/EventPreview.tsx
+++ b/apps/server/src/components/admin/events/EventPreview.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { CardDescription } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import type { EventListItem } from "./types";
-import { formatDisplayDate } from "./utils";
+import { formatDisplayDate } from "@/lib/datetime";
 
 type EventPreviewProps = {
 	event: EventListItem;

--- a/apps/server/src/components/admin/events/utils.ts
+++ b/apps/server/src/components/admin/events/utils.ts
@@ -1,8 +1,0 @@
-import { format } from "date-fns";
-
-export function formatDisplayDate(value: string | Date | null | undefined) {
-	if (!value) return "";
-	const date = value instanceof Date ? value : new Date(value);
-	if (Number.isNaN(date.getTime())) return "";
-	return format(date, "MMM d, yyyy p");
-}

--- a/apps/server/src/lib/datetime.ts
+++ b/apps/server/src/lib/datetime.ts
@@ -1,0 +1,15 @@
+import { format } from "date-fns";
+
+export function formatDateTimeLocal(value: string | Date | null | undefined) {
+        if (!value) return "";
+        const date = value instanceof Date ? value : new Date(value);
+        if (Number.isNaN(date.getTime())) return "";
+        return format(date, "yyyy-MM-dd'T'HH:mm");
+}
+
+export function formatDisplayDate(value: string | Date | null | undefined) {
+        if (!value) return "";
+        const date = value instanceof Date ? value : new Date(value);
+        if (Number.isNaN(date.getTime())) return "";
+        return format(date, "MMM d, yyyy p");
+}


### PR DESCRIPTION
## Summary
- extract the event detail sheet markup into a dedicated `EventDetailSheet` component powered by shared date helpers
- add an `EventEditDialog` component that owns the edit form state and relies on the shared datetime utilities
- move date formatting helpers into `apps/server/src/lib/datetime.ts`, update the admin events page to consume the new components, and refresh related imports

## Testing
- bunx tsc --noEmit *(fails: existing type errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_b_68d4f27334208327b11d38c6e9381747