### PR TITLE
Fix auth client type inference

### DIFF
--- a/apps/server/src/lib/auth-client.ts
+++ b/apps/server/src/lib/auth-client.ts
@@ -4,12 +4,12 @@ import {
 	organizationClient,
 } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
-import type { auth } from "./auth";
+type AuthInstance = typeof import("./auth").auth;
 
 export const authClient = createAuthClient({
 	plugins: [
 		organizationClient({
-			schema: inferOrgAdditionalFields<typeof auth>(),
+			schema: inferOrgAdditionalFields<AuthInstance>(),
 		}),
 		adminClient(),
 	],


### PR DESCRIPTION
## Summary
- derive the organization schema type using a local AuthInstance alias rather than a type-only import in auth-client

## Testing
- bun run --filter server build

------
https://chatgpt.com/codex/tasks/task_b_68d4fbada5388327b829d985d6b7e9c3