### PR TITLE
fix: render anchors for non-route links

### DIFF
--- a/apps/server/src/app/(site)/admin/overview/page.tsx
+++ b/apps/server/src/app/(site)/admin/overview/page.tsx
@@ -51,9 +51,9 @@ export default function HomePage() {
 								Launch the console
 							</Link>
 						</Button>
-						<Button asChild variant="outline" size="lg">
-							<Link href="#highlights">Explore features</Link>
-						</Button>
+                                                <Button asChild variant="outline" size="lg">
+                                                        <a href="#highlights">Explore features</a>
+                                                </Button>
 					</CardContent>
 				</Card>
 
@@ -117,9 +117,9 @@ export default function HomePage() {
 					<Button asChild>
 						<Link href="/auth/sign-in">Sign in to continue</Link>
 					</Button>
-					<Button asChild variant="ghost">
-						<Link href="mailto:team@calendarsync.app">Contact support</Link>
-					</Button>
+                                        <Button asChild variant="ghost">
+                                                <a href="mailto:team@calendarsync.app">Contact support</a>
+                                        </Button>
 				</div>
 			</section>
 		</AppShell>

--- a/apps/server/src/app/(site)/admin/users/page.tsx
+++ b/apps/server/src/app/(site)/admin/users/page.tsx
@@ -4,7 +4,6 @@ import { RedirectToSignIn } from "@daveyplate/better-auth-ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import { MoreHorizontal } from "lucide-react";
-import Link from "next/link";
 import * as React from "react";
 import { toast } from "sonner";
 
@@ -550,12 +549,12 @@ export default function AdminUsersPage() {
 															<div className="font-medium text-foreground text-sm">
 																{item.name || "Unnamed user"}
 															</div>
-															<Link
-																href={`mailto:${item.email}`}
-																className="text-muted-foreground text-sm hover:underline"
-															>
-																{item.email}
-															</Link>
+                                                                                                                        <a
+                                                                                                                               href={`mailto:${item.email}`}
+                                                                                                                               className="text-muted-foreground text-sm hover:underline"
+                                                                                                                        >
+                                                                                                                               {item.email}
+                                                                                                                        </a>
 														</div>
 													</div>
 												</TableCell>

--- a/apps/server/src/components/Home.tsx
+++ b/apps/server/src/components/Home.tsx
@@ -133,23 +133,37 @@ export default function Home() {
 								<SidebarGroupLabel>{group.label}</SidebarGroupLabel>
 								<SidebarGroupContent>
 									<SidebarMenu>
-										{group.items.map((item) => (
-											<SidebarMenuItem key={item.title}>
-												<SidebarMenuButton asChild isActive={item.href === "/"}>
-													<Link
-														href={item.href}
-														className="flex items-center gap-2"
-													>
-														<item.icon className="size-4" />
-														<span>{item.title}</span>
-													</Link>
-												</SidebarMenuButton>
-											</SidebarMenuItem>
-										))}
-									</SidebarMenu>
-								</SidebarGroupContent>
-							</SidebarGroup>
-						))}
+                                                                                {group.items.map((item) => {
+                                                                                        const isAnchorLink = item.href.startsWith("#");
+
+                                                                                        return (
+                                                                                                <SidebarMenuItem key={item.title}>
+                                                                                                        <SidebarMenuButton asChild isActive={item.href === "/"}>
+                                                                                                                {isAnchorLink ? (
+                                                                                                                        <a
+                                                                                                                                href={item.href}
+                                                                                                                                className="flex items-center gap-2"
+                                                                                                                        >
+                                                                                                                                <item.icon className="size-4" />
+                                                                                                                                <span>{item.title}</span>
+                                                                                                                        </a>
+                                                                                                                ) : (
+                                                                                                                        <Link
+                                                                                                                                href={item.href}
+                                                                                                                                className="flex items-center gap-2"
+                                                                                                                        >
+                                                                                                                                <item.icon className="size-4" />
+                                                                                                                                <span>{item.title}</span>
+                                                                                                                        </Link>
+                                                                                                                )}
+                                                                                                        </SidebarMenuButton>
+                                                                                                </SidebarMenuItem>
+                                                                                        );
+                                                                                })}
+                                                                        </SidebarMenu>
+                                                                </SidebarGroupContent>
+                                                        </SidebarGroup>
+                                                ))}
 					</SidebarContent>
 					<SidebarFooter>
 						<div className="rounded-lg border border-dashed p-3 text-sidebar-foreground/80 text-xs">
@@ -204,9 +218,9 @@ export default function Home() {
 											Launch the console
 										</Link>
 									</Button>
-									<Button asChild variant="outline" size="lg">
-										<Link href="#highlights">Explore features</Link>
-									</Button>
+                                                                        <Button asChild variant="outline" size="lg">
+                                                                                <a href="#highlights">Explore features</a>
+                                                                        </Button>
 								</CardContent>
 							</Card>
 							<Card>
@@ -276,18 +290,16 @@ export default function Home() {
 								</p>
 							</div>
 							<div className="flex flex-wrap gap-3">
-								<Button asChild>
-									<Link href="/auth/sign-in">Sign in to continue</Link>
-								</Button>
-								<Button asChild variant="ghost">
-									<Link href="mailto:team@calendarsync.app">
-										Contact support
-									</Link>
-								</Button>
-							</div>
-						</section>
-					</div>
-				</SidebarInset>
+                                                                <Button asChild>
+                                                                        <Link href="/auth/sign-in">Sign in to continue</Link>
+                                                                </Button>
+                                                                <Button asChild variant="ghost">
+                                                                        <a href="mailto:team@calendarsync.app">Contact support</a>
+                                                                </Button>
+                                                        </div>
+                                                </section>
+                                        </div>
+                                </SidebarInset>
 			</div>
 		</SidebarProvider>
 	);


### PR DESCRIPTION
## Summary
- render sidebar hash navigation and CTA mailto links in the home component with plain anchors instead of next/link
- update the admin overview CTAs to use anchor tags for hash fragments and mailto targets
- switch the admin users email link to an anchor to avoid typed-route issues with mailto URLs

## Testing
- bun run build *(fails: Next.js cannot download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d5157dad348327b1154b32eb1dddd6