### PR TITLE
Use typed router push for provider admin

### DIFF
--- a/apps/server/src/app/(site)/admin/providers/page.tsx
+++ b/apps/server/src/app/(site)/admin/providers/page.tsx
@@ -39,7 +39,9 @@ export default function ProvidersAdminPage() {
 	const smtpTestMutation = useTestCatalogSmtp();
 	const deleteMutation = useDeleteCatalogProvider();
 
-	const rows = providersQuery.data ?? [];
+        const rows =
+                providersQuery.data ??
+                ([] as NonNullable<typeof providersQuery.data>);
 
 	const renderStatusBadge = (status: string) => {
 		const normalized = status.toLowerCase();
@@ -186,13 +188,18 @@ export default function ProvidersAdminPage() {
 													>
 														Test SMTP
 													</Button>
-													<Button
-														variant="default"
-														size="sm"
-														onClick={() =>
-															router.push(`/admin/providers/${row.id}`)
-														}
-													>
+                                                                                                        <Button
+                                                                                                                variant="default"
+                                                                                                                size="sm"
+                                                                                                                onClick={() =>
+                                                                                                                        router.push({
+                                                                                                                                pathname: "/admin/providers/[providerId]",
+                                                                                                                                params: {
+                                                                                                                                        providerId: row.id,
+                                                                                                                                },
+                                                                                                                        })
+                                                                                                                }
+                                                                                                        >
 														Edit
 													</Button>
 													<Button


### PR DESCRIPTION
## Summary
- use the typed router.push helper for provider edit navigation in the admin providers table
- ensure provider rows are typed so the route parameter is always a string

## Testing
- bun run build *(fails: unable to download remote font assets during Next.js build)*

------
https://chatgpt.com/codex/tasks/task_b_68d516444c7c8327b5d81309e3e0cd17