### PR TITLE
Use object form redirect for admin cal slug page

### DIFF
--- a/apps/server/src/app/(site)/admin/cals/[slug]/page.tsx
+++ b/apps/server/src/app/(site)/admin/cals/[slug]/page.tsx
@@ -4,7 +4,7 @@ type SlugPageParams = Promise<{ slug: string }>;
 
 const page = async ({ params }: { params: SlugPageParams }) => {
 	const { slug } = await params;
-	redirect(`/admin/cals/${slug}/settings`);
+	redirect({ pathname: "/admin/cals/[slug]/settings", params: { slug } });
 };
 
 export default page;


### PR DESCRIPTION
## Summary
- use Next.js object-form redirect on the admin calendar slug page so the slug is passed separately from the pathname template

## Testing
- bun run build *(fails: unable to download https://fonts.gstatic.com/s/geistmono/v4/or3nQ6H-1_WfwkMZI_qYFrcdmhHkjko.woff2)*

------
https://chatgpt.com/codex/tasks/task_b_68d517a494e083279c7f7e11964efe45