### PR TITLE
Fix admin event filters router replace query handling

### DIFF
--- a/apps/server/src/app/(site)/admin/events/useEventFilters.ts
+++ b/apps/server/src/app/(site)/admin/events/useEventFilters.ts
@@ -96,16 +96,25 @@ export function useEventFilters(
 			skipSearchSyncRef.current = false;
 			return;
 		}
-		const nextParams = filtersToSearchParams(filters);
-		const nextString = nextParams.toString();
-		if (nextString === searchParamsString) {
-			return;
-		}
-		skipSearchSyncRef.current = true;
-		router.replace(nextString ? `${pathname}?${nextString}` : pathname, {
-			scroll: false,
-		});
-	}, [filters, pathname, router, searchParamsString]);
+                const nextParams = filtersToSearchParams(filters);
+                const nextString = nextParams.toString();
+                if (nextString === searchParamsString) {
+                        return;
+                }
+                skipSearchSyncRef.current = true;
+                const queryEntries = Array.from(nextParams.entries()).map<[string, string]>(
+                        ([key, value]) => [key, value],
+                );
+                const query = Object.fromEntries(queryEntries);
+                router.replace(
+                        queryEntries.length > 0
+                                ? { pathname, query }
+                                : { pathname },
+                        {
+                                scroll: false,
+                        },
+                );
+        }, [filters, pathname, router, searchParamsString]);
 
 	useEffect(() => {
 		if (skipSearchSyncRef.current) {


### PR DESCRIPTION
## Summary
- derive a plain object query from URLSearchParams entries for the admin events filters
- update router.replace to use typed pathname/query options and fall back to pathname-only when empty

## Testing
- NEXT_DISABLE_FONT_OPTIMIZATION=1 bun run build *(fails: Next.js build cannot download remote Geist fonts in offline environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d5186d509c8327af9bcb624be1185e