### PR TITLE
Normalize admin role handling

### DIFF
--- a/apps/server/src/app/(api)/admin/logs/stream/route.ts
+++ b/apps/server/src/app/(api)/admin/logs/stream/route.ts
@@ -16,15 +16,14 @@ app.use(async (c, next) => {
 		return c.json({ error: "Unauthorized" }, 401);
 	}
 
-	const roleCandidates = Array.isArray(context.session.user?.roles)
-		? context.session.user.roles
-		: context.session.user?.role
-			? [context.session.user.role]
-			: [];
+        const userRole = (context.session.user as typeof context.session.user & {
+                role?: string | null;
+        })?.role;
+        const roles = userRole ? [userRole] : [];
 
-	if (!roleCandidates.includes("admin")) {
-		return c.json({ error: "Forbidden" }, 403);
-	}
+        if (!roles.includes("admin")) {
+                return c.json({ error: "Forbidden" }, 403);
+        }
 
 	c.set("session", context.session);
 	await next();

--- a/apps/server/src/app/(site)/admin/layout.tsx
+++ b/apps/server/src/app/(site)/admin/layout.tsx
@@ -18,15 +18,14 @@ export default async function AdminLayout({
 		redirect("/auth/sign-in");
 	}
 
-	const roles = Array.isArray(session.user?.roles)
-		? session.user.roles
-		: session.user?.role
-			? [session.user.role]
-			: [];
+        const userRole = (session.user as typeof session.user & {
+                role?: string | null;
+        })?.role;
+        const roles = userRole ? [userRole] : [];
 
-	if (!roles?.includes("admin")) {
-		redirect("/");
-	}
+        if (!roles.includes("admin")) {
+                redirect("/");
+        }
 
 	return <RequireAdmin>{children}</RequireAdmin>;
 }

--- a/apps/server/src/components/admin/RequireAdmin.tsx
+++ b/apps/server/src/components/admin/RequireAdmin.tsx
@@ -22,17 +22,16 @@ export function RequireAdmin({ children }: { children: React.ReactNode }) {
 			return;
 		}
 
-		const roles = Array.isArray(session.user?.roles)
-			? session.user?.roles
-			: session.user?.role
-				? [session.user.role]
-				: [];
+                const userRole = (session.user as typeof session.user & {
+                        role?: string | null;
+                })?.role;
+                const roles = userRole ? [userRole] : [];
 
-		if (!roles?.includes("admin")) {
-			toast.error("Administrator access required");
-			router.replace("/");
-			return;
-		}
+                if (!roles.includes("admin")) {
+                        toast.error("Administrator access required");
+                        router.replace("/");
+                        return;
+                }
 
 		setIsAuthorized(true);
 	}, [isPending, router, session]);

--- a/apps/server/src/lib/trpc.ts
+++ b/apps/server/src/lib/trpc.ts
@@ -24,18 +24,17 @@ export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
 });
 
 export const adminProcedure = protectedProcedure.use(({ ctx, next }) => {
-	const roleCandidates = Array.isArray(ctx.session.user?.roles)
-		? ctx.session.user.roles
-		: ctx.session.user?.role
-			? [ctx.session.user.role]
-			: [];
+        const userRole = (ctx.session.user as typeof ctx.session.user & {
+                role?: string | null;
+        })?.role;
+        const roles = userRole ? [userRole] : [];
 
-	if (!roleCandidates?.includes("admin")) {
-		throw new TRPCError({
-			code: "FORBIDDEN",
-			message: "Administrator permissions are required",
-		});
-	}
+        if (!roles.includes("admin")) {
+                throw new TRPCError({
+                        code: "FORBIDDEN",
+                        message: "Administrator permissions are required",
+                });
+        }
 
 	return next();
 });


### PR DESCRIPTION
## Summary
- normalize role checks in admin guards by deriving an array from the single session user role
- ensure both server-side and client-side admin gates share the same role extraction logic
- keep TRPC admin procedure aligned with the updated role handling

## Testing
- bunx tsc --noEmit -p apps/server/tsconfig.json *(fails: existing type errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_b_68d5207a15b88327aec7e574f9d9ee04