### PR TITLE
Use string URLs for admin navigation helpers

### DIFF
--- a/apps/server/src/app/(site)/admin/cals/[slug]/page.tsx
+++ b/apps/server/src/app/(site)/admin/cals/[slug]/page.tsx
@@ -4,7 +4,7 @@ type SlugPageParams = Promise<{ slug: string }>;
 
 const page = async ({ params }: { params: SlugPageParams }) => {
 	const { slug } = await params;
-	redirect({ pathname: "/admin/cals/[slug]/settings", params: { slug } });
+        redirect(`/admin/cals/${slug}/settings`);
 };
 
 export default page;

--- a/apps/server/src/app/(site)/admin/events/useEventFilters.ts
+++ b/apps/server/src/app/(site)/admin/events/useEventFilters.ts
@@ -105,15 +105,9 @@ export function useEventFilters(
                 const queryEntries = Array.from(nextParams.entries()).map<[string, string]>(
                         ([key, value]) => [key, value],
                 );
-                const query = Object.fromEntries(queryEntries);
-                router.replace(
-                        queryEntries.length > 0
-                                ? { pathname, query }
-                                : { pathname },
-                        {
-                                scroll: false,
-                        },
-                );
+                const nextUrl =
+                        queryEntries.length > 0 ? `${pathname}?${nextString}` : pathname;
+                router.replace(nextUrl, { scroll: false });
         }, [filters, pathname, router, searchParamsString]);
 
 	useEffect(() => {

--- a/apps/server/src/app/(site)/admin/providers/page.tsx
+++ b/apps/server/src/app/(site)/admin/providers/page.tsx
@@ -192,12 +192,9 @@ export default function ProvidersAdminPage() {
                                                                                                                 variant="default"
                                                                                                                 size="sm"
                                                                                                                 onClick={() =>
-                                                                                                                        router.push({
-                                                                                                                                pathname: "/admin/providers/[providerId]",
-                                                                                                                                params: {
-                                                                                                                                        providerId: row.id,
-                                                                                                                                },
-                                                                                                                        })
+                                                                                                                        router.push(
+                                                                                                                                `/admin/providers/${row.id}`,
+                                                                                                                        )
                                                                                                                 }
                                                                                                         >
 														Edit


### PR DESCRIPTION
## Summary
- update the calendar slug redirect to use a formatted string path
- rebuild the admin events filter URL before replacing to match string-based navigation
- push provider detail routes with formatted string URLs

## Testing
- bunx tsc --noEmit *(fails: existing type errors in unrelated admin modules)*

------
https://chatgpt.com/codex/tasks/task_b_68d523d05d14832785fdf1b50519441e