### PR TITLE
Add placeholder legal and contact pages

### DIFF
--- a/apps/server/src/app/contact/page.tsx
+++ b/apps/server/src/app/contact/page.tsx
@@ -1,0 +1,15 @@
+export default function ContactPage() {
+        return (
+                <main className="mx-auto flex min-h-screen w-full max-w-3xl flex-col gap-6 px-6 py-16">
+                        <h1 className="text-3xl font-semibold tracking-tight text-slate-900">Contact Us</h1>
+                        <p className="text-base leading-relaxed text-slate-600">
+                                Need assistance or have feedback for CalendarSync? Send us a message at
+                                support@calendarsync.app and we&apos;ll get back to you as soon as we can.
+                        </p>
+                        <p className="text-base leading-relaxed text-slate-600">
+                                We&apos;re happy to hear about feature requests, partnership ideas, or anything else that can
+                                make CalendarSync better for your team.
+                        </p>
+                </main>
+        );
+}

--- a/apps/server/src/app/privacy/page.tsx
+++ b/apps/server/src/app/privacy/page.tsx
@@ -1,0 +1,14 @@
+export default function PrivacyPage() {
+        return (
+                <main className="mx-auto flex min-h-screen w-full max-w-3xl flex-col gap-6 px-6 py-16">
+                        <h1 className="text-3xl font-semibold tracking-tight text-slate-900">Privacy Policy</h1>
+                        <p className="text-base leading-relaxed text-slate-600">
+                                This is a placeholder for the CalendarSync privacy policy. We&apos;re working on the
+                                full details to explain how we collect, use, and protect your data.
+                        </p>
+                        <p className="text-base leading-relaxed text-slate-600">
+                                In the meantime, if you have any questions, feel free to reach out at support@calendarsync.app.
+                        </p>
+                </main>
+        );
+}

--- a/apps/server/src/app/terms/page.tsx
+++ b/apps/server/src/app/terms/page.tsx
@@ -1,0 +1,15 @@
+export default function TermsPage() {
+        return (
+                <main className="mx-auto flex min-h-screen w-full max-w-3xl flex-col gap-6 px-6 py-16">
+                        <h1 className="text-3xl font-semibold tracking-tight text-slate-900">Terms of Service</h1>
+                        <p className="text-base leading-relaxed text-slate-600">
+                                These are the placeholder terms for using CalendarSync. The full agreement will cover
+                                acceptable use, account responsibilities, and service limitations.
+                        </p>
+                        <p className="text-base leading-relaxed text-slate-600">
+                                Until the official document is published, please contact our team with any questions
+                                about how the service is provided.
+                        </p>
+                </main>
+        );
+}


### PR DESCRIPTION
## Summary
- add basic placeholder routes for the privacy policy, terms of service, and contact pages

## Testing
- `npx tsc --noEmit -p apps/server/tsconfig.json` *(fails: existing type errors in admin event and log modules)*

------
https://chatgpt.com/codex/tasks/task_b_68d524e9655883278ee9ad7615f26749