### PR TITLE
refactor: strengthen admin query typing

### DIFF
--- a/apps/server/src/app/(site)/admin/events/event-filters.ts
+++ b/apps/server/src/app/(site)/admin/events/event-filters.ts
@@ -1,7 +1,3 @@
-import type { inferRouterInputs } from "@trpc/server";
-
-import type { AppRouter } from "@/routers";
-
 export const EVENT_FILTER_STORAGE_KEY = "admin.events.filters";
 
 export const eventStatuses = ["pending", "approved", "rejected"] as const;
@@ -17,13 +13,20 @@ export const statusOptionMap: Record<
 	rejected: { label: "Rejected", badgeVariant: "outline" },
 };
 
-type RouterInputs = inferRouterInputs<AppRouter>;
-
-type EventsListInput = RouterInputs["events"]["list"];
-export type EventsListFilters = Omit<
-	NonNullable<EventsListInput>,
-	"page" | "limit"
->;
+export interface EventsListFilters {
+        providerId?: string;
+        status?: EventStatus;
+        flagId?: string | null;
+        isPublished?: boolean;
+        isAllDay?: boolean;
+        q?: string;
+        startFrom?: string;
+        startTo?: string;
+        priority?: {
+                min?: number;
+                max?: number;
+        };
+}
 
 export type Filters = {
 	q: string;
@@ -141,24 +144,25 @@ export function readStoredFilters(): Filters | null {
 }
 
 export function buildListInput(
-	filters: Filters,
+        filters: Filters,
 ): EventsListFilters | undefined {
-	const input: EventsListFilters = {};
-	if (filters.q.trim()) input.q = filters.q.trim();
-	if (filters.status !== "all") input.status = filters.status;
-	if (filters.providerId) input.providerId = filters.providerId;
-	if (filters.publishedOnly) input.isPublished = true;
-	if (filters.allDayOnly) input.isAllDay = true;
-	if (filters.startFrom) {
-		input.startFrom = new Date(`${filters.startFrom}T00:00:00Z`).toISOString();
-	}
-	if (filters.startTo) {
-		input.startTo = new Date(`${filters.startTo}T23:59:59Z`).toISOString();
-	}
-	if (filters.priorityMin !== null || filters.priorityMax !== null) {
-		input.priority = {};
-		if (filters.priorityMin !== null) input.priority.min = filters.priorityMin;
-		if (filters.priorityMax !== null) input.priority.max = filters.priorityMax;
-	}
-	return Object.keys(input).length ? input : undefined;
+        const input: EventsListFilters = {};
+        if (filters.q.trim()) input.q = filters.q.trim();
+        if (filters.status !== "all") input.status = filters.status;
+        if (filters.providerId) input.providerId = filters.providerId;
+        if (filters.publishedOnly) input.isPublished = true;
+        if (filters.allDayOnly) input.isAllDay = true;
+        if (filters.startFrom) {
+                input.startFrom = new Date(`${filters.startFrom}T00:00:00Z`).toISOString();
+        }
+        if (filters.startTo) {
+                input.startTo = new Date(`${filters.startTo}T23:59:59Z`).toISOString();
+        }
+        if (filters.priorityMin !== null || filters.priorityMax !== null) {
+                const priority: NonNullable<EventsListFilters["priority"]> = {};
+                if (filters.priorityMin !== null) priority.min = filters.priorityMin;
+                if (filters.priorityMax !== null) priority.max = filters.priorityMax;
+                input.priority = priority;
+        }
+        return Object.keys(input).length ? input : undefined;
 }

--- a/apps/server/src/app/(site)/admin/logs/page.tsx
+++ b/apps/server/src/app/(site)/admin/logs/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { RedirectToSignIn } from "@daveyplate/better-auth-ui";
+import { useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
+import type { inferRouterOutputs } from "@trpc/server";
 
 import AppShell from "@/components/layout/AppShell";
 import { UserAvatar } from "@/components/UserAvatar";
@@ -42,7 +44,12 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import { useAdminLogStream, useAdminLogs } from "@/hooks/use-admin-logs";
-import { useCatalogList } from "@/hooks/use-provider-admin";
+import { providerKeys } from "@/lib/query-keys/providers";
+import { trpcClient } from "@/lib/trpc-client";
+import type { AppRouter } from "@/routers";
+
+type RouterOutputs = inferRouterOutputs<AppRouter>;
+type ProvidersCatalogListOutput = RouterOutputs["providers"]["catalog"]["list"];
 
 const LOG_LEVELS = [
 	{ value: "debug", label: "Debug" },
@@ -85,7 +92,10 @@ export default function AdminLogsPage() {
 	const [providerFilter, setProviderFilter] = useState<string | null>(null);
 	const [levelFilter, setLevelFilter] = useState<string | null>(null);
 
-	const providerQuery = useCatalogList();
+        const providerQuery = useQuery<ProvidersCatalogListOutput>({
+                queryKey: providerKeys.catalog.list(),
+                queryFn: () => trpcClient.providers.catalog.list.query(),
+        });
 	const logsQuery = useAdminLogs({
 		providerId: providerFilter,
 		level: levelFilter,

--- a/apps/server/src/app/(site)/admin/providers/page.tsx
+++ b/apps/server/src/app/(site)/admin/providers/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useQuery } from "@tanstack/react-query";
 import { RedirectToSignIn } from "@daveyplate/better-auth-ui";
 import { formatDistanceToNow } from "date-fns";
 import { useRouter } from "next/navigation";
+import type { inferRouterOutputs } from "@trpc/server";
 
 import AppShell from "@/components/layout/AppShell";
 import { UserAvatar } from "@/components/UserAvatar";
@@ -26,22 +28,28 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import {
-	useCatalogList,
-	useDeleteCatalogProvider,
-	useTestCatalogImap,
-	useTestCatalogSmtp,
+        useDeleteCatalogProvider,
+        useTestCatalogImap,
+        useTestCatalogSmtp,
 } from "@/hooks/use-provider-admin";
+import { providerKeys } from "@/lib/query-keys/providers";
+import { trpcClient } from "@/lib/trpc-client";
+import type { AppRouter } from "@/routers";
+
+type RouterOutputs = inferRouterOutputs<AppRouter>;
+type CatalogListOutput = RouterOutputs["providers"]["catalog"]["list"];
 
 export default function ProvidersAdminPage() {
 	const router = useRouter();
-	const providersQuery = useCatalogList();
+        const providersQuery = useQuery<CatalogListOutput>({
+                queryKey: providerKeys.catalog.list(),
+                queryFn: () => trpcClient.providers.catalog.list.query(),
+        });
 	const imapTestMutation = useTestCatalogImap();
 	const smtpTestMutation = useTestCatalogSmtp();
 	const deleteMutation = useDeleteCatalogProvider();
 
-        const rows =
-                providersQuery.data ??
-                ([] as NonNullable<typeof providersQuery.data>);
+        const rows = providersQuery.data ?? [];
 
 	const renderStatusBadge = (status: string) => {
 		const normalized = status.toLowerCase();


### PR DESCRIPTION
## Summary
- define an explicit EventsListFilters interface and keep buildListInput strongly typed
- ensure AdminEventsPage queries, cache helpers, and patches use typed TRPC data
- type provider list queries across logs, provider management, and calendar components
- tighten AdminUsersPage list typing and optimistic updates to remove implicit anys

## Testing
- bunx tsc --noEmit *(fails: existing type errors in unrelated admin modules)*

------
https://chatgpt.com/codex/tasks/task_b_68d526559fec832783bfac686f65099f