### PR TITLE
Add placeholder data for admin queries

### DIFF
--- a/apps/server/src/app/(site)/admin/events/page.tsx
+++ b/apps/server/src/app/(site)/admin/events/page.tsx
@@ -163,6 +163,7 @@ export default function AdminEventsPage() {
         const eventsQuery = useQuery<EventsListOutput>({
                 queryKey: listQueryKey,
                 queryFn: () => trpcClient.events.list.query(listParams),
+                placeholderData: (previous) => previous,
         });
 
 	const events = useMemo(

--- a/apps/server/src/app/(site)/admin/users/page.tsx
+++ b/apps/server/src/app/(site)/admin/users/page.tsx
@@ -149,6 +149,7 @@ export default function AdminUsersPage() {
         >({
                 queryKey: listKey,
                 queryFn: () => trpcClient.adminUsers.list.query(listParams),
+                placeholderData: (previous) => previous,
         });
 
         const rolesQuery = useQuery<RolesOptionsOutput>({


### PR DESCRIPTION
## Summary
- use placeholderData to preserve cached event results while fetching
- apply the same placeholder behavior to the admin users list query

## Testing
- bunx tsc --noEmit *(fails: pre-existing type errors in admin flags/logs and router files)*

------
https://chatgpt.com/codex/tasks/task_b_68d52ad3e6ac8327a825c7ae60632a07