### PR TITLE
Add org list router and recent event helpers

### DIFF
--- a/apps/server/src/lib/query-keys/orgs.ts
+++ b/apps/server/src/lib/query-keys/orgs.ts
@@ -1,7 +1,19 @@
+export type OrgListKeyParams = {
+        segment: "joined" | "discover";
+        search?: string | null;
+        limit?: number | null;
+        sort?: string | null;
+};
+
 export const orgsKeys = {
         all: ["orgs"] as const,
-        joined: (filters?: { search?: string | null; limit?: number }) =>
-                [...orgsKeys.all, "joined", filters?.search ?? null, filters?.limit ?? null] as const,
-        discover: (filters?: { search?: string | null; limit?: number }) =>
-                [...orgsKeys.all, "discover", filters?.search ?? null, filters?.limit ?? null] as const,
+        list: (params: OrgListKeyParams) =>
+                [
+                        ...orgsKeys.all,
+                        "listForUser",
+                        params.segment,
+                        params.search ?? null,
+                        params.limit ?? null,
+                        params.sort ?? null,
+                ] as const,
 };

--- a/apps/server/src/lib/trpc-client.ts
+++ b/apps/server/src/lib/trpc-client.ts
@@ -2,6 +2,8 @@ import { QueryCache, QueryClient } from "@tanstack/react-query";
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import { createTRPCOptionsProxy } from "@trpc/tanstack-react-query";
 import { toast } from "sonner";
+import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
+
 import type { AppRouter } from "@/routers";
 
 export const queryClient = new QueryClient({
@@ -34,6 +36,28 @@ export const trpcClient = createTRPCClient<AppRouter>({
 });
 
 export const trpc = createTRPCOptionsProxy<AppRouter>({
-	client: trpcClient,
-	queryClient,
+        client: trpcClient,
+        queryClient,
 });
+
+type RouterInputs = inferRouterInputs<AppRouter>;
+type RouterOutputs = inferRouterOutputs<AppRouter>;
+
+type ListForUserInput = RouterInputs["orgs"]["listForUser"];
+type ListForUserOutput = RouterOutputs["orgs"]["listForUser"];
+
+export const eventsApi = {
+        listRecentForUser: (input?: RouterInputs["events"]["listRecentForUser"]) =>
+                trpcClient.events.listRecentForUser.query(input),
+};
+
+export const orgsApi = {
+        listForUser: async <TSegment extends ListForUserInput["segment"]>(
+                input: ListForUserInput & { segment: TSegment },
+        ) =>
+                (await trpcClient.orgs.listForUser.query(input)) as Extract<
+                        ListForUserOutput,
+                        { segment: TSegment }
+                >,
+        join: (input: RouterInputs["orgs"]["join"]) => trpcClient.orgs.join.mutate(input),
+};

--- a/apps/server/src/routers/orgs.ts
+++ b/apps/server/src/routers/orgs.ts
@@ -18,111 +18,208 @@ import { member, organization } from "@/db/schema/auth";
 import { protectedProcedure, router } from "@/lib/trpc";
 
 const DEFAULT_PAGE_SIZE = 6;
+const joinedSortValues = ["recent", "name-asc"] as const;
+const discoverSortValues = ["name-asc", "members-desc"] as const;
 
-const searchSchema = z
-        .object({
-                search: z.string().trim().min(1).max(120).optional(),
-                page: z.number().int().min(1).optional(),
-                limit: z.number().int().min(1).max(24).optional(),
-        })
-        .optional();
+type JoinedSort = (typeof joinedSortValues)[number];
+type DiscoverSort = (typeof discoverSortValues)[number];
+
+type SessionUser = {
+        id: string;
+        banned?: boolean | null;
+        role?: string | null;
+        roles?: string[] | null;
+};
+
+const listForUserInput = z.object({
+        segment: z.enum(["joined", "discover"]).default("joined"),
+        search: z.string().trim().min(1).max(120).optional(),
+        page: z.number().int().min(1).optional(),
+        limit: z.number().int().min(1).max(24).optional(),
+        sort: z.string().optional(),
+});
+
+const joinInput = z.object({
+        organizationId: z.string().min(1),
+});
 
 function parseMetadata(value: string | null) {
         if (!value) return null;
+
         try {
                 const parsed = JSON.parse(value) as unknown;
-                return typeof parsed === "object" && parsed ? (parsed as Record<string, unknown>) : null;
+                return typeof parsed === "object" && parsed
+                        ? (parsed as Record<string, unknown>)
+                        : null;
         } catch (error) {
                 console.error("Failed to parse organization metadata", error);
                 return null;
         }
 }
 
+function resolveUserRoles(user: SessionUser) {
+        const roles = new Set<string>();
+
+        if (typeof user.role === "string" && user.role.trim().length > 0) {
+                roles.add(user.role.trim());
+        }
+
+        if (Array.isArray(user.roles)) {
+                for (const role of user.roles) {
+                        if (typeof role === "string" && role.trim().length > 0) {
+                                roles.add(role.trim());
+                        }
+                }
+        }
+
+        return roles;
+}
+
+function ensureUserCanJoin(user: SessionUser | null | undefined) {
+        if (!user) {
+                throw new TRPCError({
+                        code: "UNAUTHORIZED",
+                        message: "Authentication required",
+                });
+        }
+
+        if (user.banned) {
+                throw new TRPCError({
+                        code: "FORBIDDEN",
+                        message: "Your account is currently restricted",
+                });
+        }
+
+        const roles = resolveUserRoles(user);
+        const normalizedRoles = roles.size > 0 ? roles : new Set<string>(["user"]);
+        const allowed = new Set(["admin", "owner", "member", "user"]);
+        const hasPermission = Array.from(normalizedRoles).some((role) => allowed.has(role));
+
+        if (!hasPermission) {
+                throw new TRPCError({
+                        code: "FORBIDDEN",
+                        message: "You do not have permission to join organizations",
+                });
+        }
+}
+
+function applySearchFilter(filters: SQL[], search?: string) {
+        if (!search) {
+                return filters;
+        }
+
+        const trimmed = search.trim();
+        if (trimmed.length === 0) {
+                return filters;
+        }
+
+        filters.push(ilike(organization.name, `%${trimmed}%`));
+        return filters;
+}
+
 export const orgsRouter = router({
-        joined: protectedProcedure.input(searchSchema).query(async ({ ctx, input }) => {
-                const limit = input?.limit ?? DEFAULT_PAGE_SIZE;
-                const page = input?.page ?? 1;
-                const offset = (page - 1) * limit;
+        listForUser: protectedProcedure
+                .input(listForUserInput)
+                .query(async ({ ctx, input }) => {
+                        const userId = ctx.session.user.id;
+                        const segment = input.segment;
+                        const page = input.page ?? 1;
+                        const limit = input.limit ?? DEFAULT_PAGE_SIZE;
+                        const offset = (page - 1) * limit;
 
-                const filters: SQL[] = [eq(member.userId, ctx.session.user.id)];
-                if (input?.search) {
-                        filters.push(ilike(organization.name, `%${input.search}%`));
-                }
+                        if (segment === "joined") {
+                                const sortValue = joinedSortValues.includes(input.sort as JoinedSort)
+                                        ? (input.sort as JoinedSort)
+                                        : ("recent" satisfies JoinedSort);
 
-                const whereCondition = filters.length === 1 ? filters[0] : and(...filters);
+                                const filters: SQL[] = [eq(member.userId, userId)];
+                                applySearchFilter(filters, input.search);
 
-                const rows = await db
-                        .select({
-                                id: organization.id,
-                                name: organization.name,
-                                slug: organization.slug,
-                                logo: organization.logo,
-                                metadata: organization.metadata,
-                                joinedAt: member.createdAt,
-                                role: member.role,
-                        })
-                        .from(member)
-                        .innerJoin(organization, eq(member.organizationId, organization.id))
-                        .where(whereCondition)
-                        .orderBy(desc(member.createdAt))
-                        .offset(offset)
-                        .limit(limit + 1);
+                                const whereCondition = filters.length === 1 ? filters[0] : and(...filters);
 
-                const items = rows.slice(0, limit).map((row) => ({
-                        id: row.id,
-                        name: row.name,
-                        slug: row.slug,
-                        logo: row.logo,
-                        metadata: parseMetadata(row.metadata),
-                        joinedAt: row.joinedAt.toISOString(),
-                        role: row.role,
-                }));
+                                const rows = await db
+                                        .select({
+                                                id: organization.id,
+                                                name: organization.name,
+                                                slug: organization.slug,
+                                                logo: organization.logo,
+                                                metadata: organization.metadata,
+                                                joinedAt: member.createdAt,
+                                                role: member.role,
+                                        })
+                                        .from(member)
+                                        .innerJoin(organization, eq(member.organizationId, organization.id))
+                                        .where(whereCondition)
+                                        .orderBy(
+                                                ...(sortValue === "recent"
+                                                        ? [desc(member.createdAt), asc(organization.name)]
+                                                        : [asc(organization.name), desc(member.createdAt)]),
+                                        )
+                                        .offset(offset)
+                                        .limit(limit + 1);
 
-                const nextPage = rows.length > limit ? page + 1 : null;
+                                const items = rows.slice(0, limit).map((row) => ({
+                                        id: row.id,
+                                        name: row.name,
+                                        slug: row.slug,
+                                        logo: row.logo,
+                                        metadata: parseMetadata(row.metadata),
+                                        joinedAt: row.joinedAt.toISOString(),
+                                        role: row.role,
+                                }));
 
-                return { items, page, nextPage } as const;
-        }),
-        discover: protectedProcedure.input(searchSchema).query(async ({ ctx, input }) => {
-                const limit = input?.limit ?? DEFAULT_PAGE_SIZE;
-                const page = input?.page ?? 1;
-                const offset = (page - 1) * limit;
+                                return {
+                                        segment: "joined" as const,
+                                        page,
+                                        limit,
+                                        sort: sortValue,
+                                        nextPage: rows.length > limit ? page + 1 : null,
+                                        items,
+                                };
+                        }
 
-                const userMembership = alias(member, "user_membership");
+                        const sortValue = discoverSortValues.includes(input.sort as DiscoverSort)
+                                ? (input.sort as DiscoverSort)
+                                : ("name-asc" satisfies DiscoverSort);
 
-                const filters: SQL[] = [isNull(userMembership.id)];
-                if (input?.search) {
-                        filters.push(ilike(organization.name, `%${input.search}%`));
-                }
+                        const userMembership = alias(member, "user_membership");
+                        const membersCountExpr = sql<number>`(
+                                SELECT count(*)::int FROM "member" m2 WHERE m2.organization_id = ${organization.id}
+                        )`;
 
-                const whereCondition = filters.length === 1 ? filters[0] : and(...filters);
+                        const filters: SQL[] = [isNull(userMembership.id)];
+                        applySearchFilter(filters, input.search);
+                        const whereCondition = filters.length === 1 ? filters[0] : and(...filters);
 
-                const rows = await db
-                        .select({
-                                id: organization.id,
-                                name: organization.name,
-                                slug: organization.slug,
-                                logo: organization.logo,
-                                metadata: organization.metadata,
-                                membersCount: sql<number>`(
-                                        SELECT count(*)::int FROM "member" m2 WHERE m2.organization_id = ${organization.id}
-                                )`,
-                        })
-                        .from(organization)
-                        .leftJoin(
-                                userMembership,
-                                and(
-                                        eq(userMembership.organizationId, organization.id),
-                                        eq(userMembership.userId, ctx.session.user.id),
-                                ),
-                        )
-                        .orderBy(asc(organization.name))
-                        .where(whereCondition)
-                        .offset(offset)
-                        .limit(limit + 1);
+                        let query = db
+                                .select({
+                                        id: organization.id,
+                                        name: organization.name,
+                                        slug: organization.slug,
+                                        logo: organization.logo,
+                                        metadata: organization.metadata,
+                                        membersCount: membersCountExpr,
+                                })
+                                .from(organization)
+                                .leftJoin(
+                                        userMembership,
+                                        and(
+                                                eq(userMembership.organizationId, organization.id),
+                                                eq(userMembership.userId, userId),
+                                        ),
+                                )
+                                .where(whereCondition)
+                                .offset(offset)
+                                .limit(limit + 1);
 
-                const items = rows
-                        .slice(0, limit)
-                        .map((row) => ({
+                        query =
+                                sortValue === "members-desc"
+                                        ? query.orderBy(desc(membersCountExpr), asc(organization.name))
+                                        : query.orderBy(asc(organization.name));
+
+                        const rows = await query;
+
+                        const items = rows.slice(0, limit).map((row) => ({
                                 id: row.id,
                                 name: row.name,
                                 slug: row.slug,
@@ -131,24 +228,25 @@ export const orgsRouter = router({
                                 membersCount: Number(row.membersCount ?? 0),
                         }));
 
-                const nextPage = rows.length > limit ? page + 1 : null;
-
-                return { items, page, nextPage } as const;
-        }),
+                        return {
+                                segment: "discover" as const,
+                                page,
+                                limit,
+                                sort: sortValue,
+                                nextPage: rows.length > limit ? page + 1 : null,
+                                items,
+                        };
+                }),
         join: protectedProcedure
-                .input(
-                        z.object({
-                                organizationId: z.string().min(1),
-                        }),
-                )
+                .input(joinInput)
                 .mutation(async ({ ctx, input }) => {
-                        const organizationId = input.organizationId;
                         const userId = ctx.session.user.id;
+                        ensureUserCanJoin(ctx.session.user as SessionUser);
 
                         const existing = await db
                                 .select({ id: member.id })
                                 .from(member)
-                                .where(and(eq(member.organizationId, organizationId), eq(member.userId, userId)))
+                                .where(and(eq(member.organizationId, input.organizationId), eq(member.userId, userId)))
                                 .limit(1);
 
                         if (existing.length > 0) {
@@ -167,7 +265,7 @@ export const orgsRouter = router({
                                         metadata: organization.metadata,
                                 })
                                 .from(organization)
-                                .where(eq(organization.id, organizationId))
+                                .where(eq(organization.id, input.organizationId))
                                 .limit(1);
 
                         const organizationRow = org.at(0);
@@ -183,7 +281,7 @@ export const orgsRouter = router({
                                 .values({
                                         id: randomUUID(),
                                         userId,
-                                        organizationId,
+                                        organizationId: input.organizationId,
                                         role: "member",
                                         createdAt: new Date(),
                                 })


### PR DESCRIPTION
## Summary
- tighten the recent event list by enforcing the default window and limit while keeping the carousel DTO
- add an orgs router with a listForUser view plus RBAC-gated join mutation and supporting query-key/client helpers
- wire the dashboard home queries/mutation through the new helpers for typed filters and optimistic updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d5576c0aa88327a4c258e6550f7437