### PR TITLE
Fix alias import for orgs router

### DIFF
--- a/apps/server/src/routers/orgs.ts
+++ b/apps/server/src/routers/orgs.ts
@@ -1,7 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import {
         SQL,
-        alias,
         and,
         asc,
         desc,
@@ -10,6 +9,7 @@ import {
         isNull,
         sql,
 } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
 


### PR DESCRIPTION
## Summary
- adjust the drizzle import in the orgs router to pull alias from the pg-core entrypoint

## Testing
- bun run --filter server build

------
https://chatgpt.com/codex/tasks/task_b_68d55e152e3c8327b72834878202bfe4