### PR TITLE
Fix dashboard carousel width constraints

### DIFF
--- a/apps/server/src/components/dashboard/SignedInHome.tsx
+++ b/apps/server/src/components/dashboard/SignedInHome.tsx
@@ -609,7 +609,7 @@ function RecentEventsCarousel({
   }
 
   return (
-    <section className="space-y-4">
+    <section className="min-w-0 space-y-4">
       <header className="flex items-center justify-between gap-4">
         <div>
           <h2 className="font-semibold text-xl tracking-tight">
@@ -644,7 +644,7 @@ function RecentEventsCarousel({
         aria-label="Recent events"
         tabIndex={0}
         onKeyDown={handleKeyDown}
-        className="flex gap-4 overflow-x-auto pb-2"
+        className="flex min-w-0 w-full max-w-full gap-4 overflow-x-auto pb-2"
       >
         {events?.map((event) => (
           <RecentEventCard key={event.id} event={event} />


### PR DESCRIPTION
## Summary
- ensure the recent events carousel section can shrink within the dashboard column by adding a `min-w-0` utility
- clamp the scroll container width with `min-w-0 w-full max-w-full` so it no longer grows beyond the viewport

## Testing
- Manual verification blocked: dashboard requires authentication and no credentials are available in the development environment

------
https://chatgpt.com/codex/tasks/task_b_68d56a712afc83279552cfa4b8e52fcc