### PR TITLE
Add user-facing events page with calendar export actions

### DIFF
--- a/apps/server/src/app/(site)/events/page.tsx
+++ b/apps/server/src/app/(site)/events/page.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import * as React from "react";
+import { AlertCircle, Filter, Loader2, RefreshCw } from "lucide-react";
+import { RedirectToSignIn } from "@daveyplate/better-auth-ui";
+import { useQuery } from "@tanstack/react-query";
+
+import { EventCard } from "@/components/events/EventCard";
+import AppShell from "@/components/layout/AppShell";
+import { UserAvatar } from "@/components/UserAvatar";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { eventKeys } from "@/lib/query-keys/events";
+import { eventsApi } from "@/lib/trpc-client";
+import { formatDateBadge, getEventTimezone } from "@/lib/calendar-links";
+import type { UpcomingEvent } from "@/types/events";
+
+const EVENTS_LIMIT = 20;
+
+function getEventDateKey(event: UpcomingEvent): string {
+  return formatDateBadge(event);
+}
+
+export default function EventsPage() {
+  const [search, setSearch] = React.useState("");
+  const [location, setLocation] = React.useState("all");
+  const [date, setDate] = React.useState("");
+
+  const eventsQuery = useQuery({
+    queryKey: eventKeys.recentForUser({ limit: EVENTS_LIMIT }),
+    queryFn: () => eventsApi.listRecentForUser({ limit: EVENTS_LIMIT }),
+  });
+
+  const events = eventsQuery.data ?? [];
+  const normalizedSearch = search.trim().toLowerCase();
+
+  const locationOptions = React.useMemo(() => {
+    const unique = new Map<string, string>();
+    for (const event of events) {
+      const label = event.location?.trim();
+      if (!label || label.length === 0) continue;
+      const key = label.toLowerCase();
+      if (!unique.has(key)) {
+        unique.set(key, label);
+      }
+    }
+    return Array.from(unique.entries())
+      .sort((a, b) => a[1].localeCompare(b[1]))
+      .map(([value, label]) => ({ value, label }));
+  }, [events]);
+
+  const filteredEvents = React.useMemo(() => {
+    if (events.length === 0) return [];
+
+    return events.filter((event) => {
+      const matchesLocation =
+        location === "all" ||
+        (event.location?.trim().toLowerCase() ?? "") === location.toLowerCase();
+
+      const matchesDate =
+        date.length === 0 || getEventDateKey(event) === date;
+
+      const matchesSearch =
+        normalizedSearch.length === 0 ||
+        [
+          event.title,
+          event.description ?? "",
+          event.organization.name,
+          event.location ?? "",
+          getEventTimezone(event) ?? "",
+        ]
+          .join(" ")
+          .toLowerCase()
+          .includes(normalizedSearch);
+
+      return matchesLocation && matchesDate && matchesSearch;
+    });
+  }, [events, location, date, normalizedSearch]);
+
+  const isFiltering =
+    normalizedSearch.length > 0 || location !== "all" || date.length > 0;
+
+  const handleResetFilters = React.useCallback(() => {
+    setSearch("");
+    setLocation("all");
+    setDate("");
+  }, []);
+
+  return (
+    <AppShell
+      breadcrumbs={[
+        { label: "Home", href: "/" },
+        { label: "Events", current: true },
+      ]}
+      headerRight={<UserAvatar />}
+    >
+      <RedirectToSignIn />
+
+      <section className="space-y-6">
+        <Card className="space-y-3 rounded-3xl border-none bg-gradient-to-r from-primary/10 via-primary/5 to-transparent p-8 text-foreground shadow-sm">
+          <div className="flex flex-col gap-2">
+            <p className="text-muted-foreground text-sm">Upcoming programming</p>
+            <h1 className="font-semibold text-3xl tracking-tight sm:text-4xl">
+              Your events at a glance
+            </h1>
+            <p className="max-w-2xl text-muted-foreground text-sm">
+              Explore approved events from the organizations you follow. Add them to your calendar in a click and stay aligned with your team.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3 text-muted-foreground text-sm">
+            <span>
+              Showing {filteredEvents.length} of {events.length} upcoming events
+            </span>
+            {eventsQuery.isLoading ? (
+              <span className="inline-flex items-center gap-2">
+                <Loader2 className="size-4 animate-spin" aria-hidden /> Loading latest schedule
+              </span>
+            ) : null}
+          </div>
+        </Card>
+
+        <FiltersPanel
+          search={search}
+          onSearchChange={setSearch}
+          location={location}
+          onLocationChange={setLocation}
+          locationOptions={locationOptions}
+          date={date}
+          onDateChange={setDate}
+          onReset={handleResetFilters}
+          isFiltering={isFiltering}
+        />
+
+        {eventsQuery.isLoading ? (
+          <EventsSkeleton />
+        ) : eventsQuery.isError ? (
+          <ErrorState onRetry={eventsQuery.refetch} />
+        ) : filteredEvents.length === 0 ? (
+          <EmptyState
+            isFiltering={isFiltering}
+            onReset={handleResetFilters}
+          />
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {filteredEvents.map((event) => (
+              <EventCard key={event.id} event={event} />
+            ))}
+          </div>
+        )}
+      </section>
+    </AppShell>
+  );
+}
+
+function FiltersPanel({
+  search,
+  onSearchChange,
+  location,
+  onLocationChange,
+  locationOptions,
+  date,
+  onDateChange,
+  onReset,
+  isFiltering,
+}: {
+  search: string;
+  onSearchChange: (value: string) => void;
+  location: string;
+  onLocationChange: (value: string) => void;
+  locationOptions: { value: string; label: string }[];
+  date: string;
+  onDateChange: (value: string) => void;
+  onReset: () => void;
+  isFiltering: boolean;
+}) {
+  return (
+    <Card className="space-y-4 rounded-2xl border border-border/60 bg-card/80 p-5 shadow-sm">
+      <div className="flex items-center gap-2 text-muted-foreground text-sm">
+        <Filter className="size-4" aria-hidden />
+        <span>Refine what you see</span>
+      </div>
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="events-search">Search</Label>
+          <Input
+            id="events-search"
+            value={search}
+            placeholder="Search by title, organization, or keyword"
+            onChange={(event) => onSearchChange(event.target.value)}
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <Label>Location</Label>
+          <Select value={location} onValueChange={onLocationChange}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="All locations" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All locations</SelectItem>
+              {locationOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="events-date">Start date</Label>
+          <Input
+            id="events-date"
+            type="date"
+            value={date}
+            onChange={(event) => onDateChange(event.target.value)}
+          />
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onReset}
+          disabled={!isFiltering}
+        >
+          <RefreshCw className="mr-2 size-4" aria-hidden /> Reset filters
+        </Button>
+        {isFiltering ? (
+          <span className="text-muted-foreground text-xs">
+            Adjust filters to broaden your view.
+          </span>
+        ) : null}
+      </div>
+    </Card>
+  );
+}
+
+function EventsSkeleton() {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, index) => (
+        <Card
+          key={index}
+          className="flex h-full flex-col gap-4 rounded-2xl border border-border/40 bg-card/60 p-5"
+        >
+          <Skeleton className="h-32 w-full rounded-xl" />
+          <div className="space-y-3">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-5 w-3/4" />
+            <Skeleton className="h-4 w-1/2" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+          <div className="mt-auto flex gap-2">
+            <Skeleton className="h-8 w-20" />
+            <Skeleton className="h-8 w-20" />
+            <Skeleton className="h-8 w-16" />
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function ErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <Card className="flex flex-col items-center gap-4 rounded-2xl border border-destructive/50 bg-destructive/10 p-8 text-center text-destructive">
+      <AlertCircle className="size-8" aria-hidden />
+      <div className="space-y-2">
+        <h2 className="font-semibold text-lg">We couldn’t load your events</h2>
+        <p className="text-sm">Check your connection and try again.</p>
+      </div>
+      <Button variant="destructive" onClick={onRetry} type="button">
+        Try again
+      </Button>
+    </Card>
+  );
+}
+
+function EmptyState({
+  isFiltering,
+  onReset,
+}: {
+  isFiltering: boolean;
+  onReset: () => void;
+}) {
+  return (
+    <Card className="flex flex-col items-center gap-4 rounded-2xl border border-dashed border-border/60 bg-card/60 p-8 text-center text-muted-foreground">
+      <div className="space-y-2">
+        <h2 className="font-semibold text-lg text-foreground">
+          {isFiltering ? "No events match your filters" : "No upcoming events"}
+        </h2>
+        <p className="text-sm">
+          {isFiltering
+            ? "Broaden your filters or clear them to see more programming."
+            : "Once organizations publish new events they’ll show up here."}
+        </p>
+      </div>
+      {isFiltering ? (
+        <Button type="button" variant="outline" onClick={onReset}>
+          Clear filters
+        </Button>
+      ) : null}
+    </Card>
+  );
+}

--- a/apps/server/src/components/events/EventCard.tsx
+++ b/apps/server/src/components/events/EventCard.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import * as React from "react";
+import { CalendarPlus, CalendarRange, MapPin } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  downloadICS,
+  getGoogleCalendarUrl,
+  getOutlookCalendarUrl,
+  getYahooCalendarUrl,
+  getEventTimezone,
+  formatEventDateRange,
+} from "@/lib/calendar-links";
+import type { UpcomingEvent } from "@/types/events";
+
+function buildDisplayRange(event: UpcomingEvent): string {
+  return formatEventDateRange(event, (start, end, timeZone) => {
+    const dateFormatter = new Intl.DateTimeFormat(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      timeZone: timeZone,
+    });
+
+    const timeFormatter = new Intl.DateTimeFormat(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone: timeZone,
+    });
+
+    const dateLabel = dateFormatter.format(start);
+    const startLabel = timeFormatter.format(start);
+    const endLabel = timeFormatter.format(end);
+
+    if (startLabel === endLabel) {
+      return `${dateLabel} · ${startLabel}`;
+    }
+
+    return `${dateLabel} · ${startLabel} – ${endLabel}`;
+  });
+}
+
+export function EventCard({ event }: { event: UpcomingEvent }) {
+  const imageUrl = event.imageUrl ?? null;
+  const calendarUrls = React.useMemo(
+    () => ({
+      google: getGoogleCalendarUrl(event),
+      outlook: getOutlookCalendarUrl(event),
+      yahoo: getYahooCalendarUrl(event),
+    }),
+    [event],
+  );
+
+  const timezone = React.useMemo(() => getEventTimezone(event), [event]);
+  const rangeLabel = React.useMemo(() => buildDisplayRange(event), [event]);
+  const description = event.description?.trim();
+
+  return (
+    <Card className="flex h-full min-w-[280px] flex-1 flex-col overflow-hidden rounded-2xl border border-border/60 bg-card/90 shadow-sm transition-shadow hover:shadow-md md:min-w-[320px]">
+      <div className="relative h-36 w-full overflow-hidden bg-gradient-to-br from-primary/10 via-muted/60 to-transparent">
+        {imageUrl ? (
+          <Image
+            src={imageUrl}
+            alt="Event artwork"
+            fill
+            className="object-cover"
+            sizes="(max-width: 768px) 100vw, 320px"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+            <CalendarRange className="size-8" aria-hidden />
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-1 flex-col gap-4 p-5">
+        <div className="space-y-2">
+          <Badge variant="secondary" className="w-fit text-xs uppercase tracking-wide">
+            {event.organization.name}
+          </Badge>
+          <h3 className="font-semibold text-lg leading-tight text-foreground">
+            {event.title}
+          </h3>
+          <p className="flex items-center gap-2 text-muted-foreground text-sm">
+            <CalendarPlus className="size-4" aria-hidden />
+            <span>
+              {rangeLabel}
+              {timezone ? <span className="ml-1 text-xs uppercase">({timezone})</span> : null}
+            </span>
+          </p>
+          {event.location ? (
+            <p className="flex items-start gap-2 text-muted-foreground text-sm">
+              <MapPin className="mt-0.5 size-4" aria-hidden />
+              <span className="line-clamp-2">{event.location}</span>
+            </p>
+          ) : null}
+        </div>
+
+        {description ? (
+          <p className="line-clamp-3 text-muted-foreground text-sm leading-relaxed">
+            {description}
+          </p>
+        ) : null}
+
+        <div className="mt-auto flex flex-wrap items-center gap-2">
+          <Button asChild size="sm" variant="secondary">
+            <a
+              href={calendarUrls.google}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Add to Google Calendar"
+            >
+              Google
+            </a>
+          </Button>
+          <Button asChild size="sm" variant="outline">
+            <a
+              href={calendarUrls.outlook}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Add to Outlook Calendar"
+            >
+              Outlook
+            </a>
+          </Button>
+          <Button asChild size="sm" variant="outline">
+            <a
+              href={calendarUrls.yahoo}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Add to Yahoo Calendar"
+            >
+              Yahoo
+            </a>
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            type="button"
+            onClick={() => downloadICS(event)}
+            aria-label="Download ICS file"
+          >
+            ICS
+          </Button>
+          {event.url ? (
+            <Button asChild size="sm" variant="ghost" className="ml-auto text-primary">
+              <Link href={event.url as string} target="_blank" rel="noopener noreferrer">
+                View details
+              </Link>
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/apps/server/src/components/layout/AppShell.tsx
+++ b/apps/server/src/components/layout/AppShell.tsx
@@ -1,149 +1,213 @@
 "use client";
 
 import { OrganizationSwitcher } from "@daveyplate/better-auth-ui";
+import { CalendarDays, LayoutDashboard, Settings } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import React from "react";
+
 import {
-	Breadcrumb,
-	BreadcrumbItem,
-	BreadcrumbLink,
-	BreadcrumbList,
-	BreadcrumbPage,
-	BreadcrumbSeparator,
+        Breadcrumb,
+        BreadcrumbItem,
+        BreadcrumbLink,
+        BreadcrumbList,
+        BreadcrumbPage,
+        BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import {
-	Sidebar,
-	SidebarContent,
-	SidebarFooter,
-	SidebarGroup,
-	SidebarGroupContent,
-	SidebarGroupLabel,
-	SidebarHeader,
-	SidebarInset,
-	SidebarMenu,
-	SidebarMenuButton,
-	SidebarMenuItem,
-	SidebarProvider,
-	SidebarSeparator,
-	SidebarTrigger,
+        Sidebar,
+        SidebarContent,
+        SidebarFooter,
+        SidebarGroup,
+        SidebarGroupContent,
+        SidebarGroupLabel,
+        SidebarHeader,
+        SidebarInset,
+        SidebarMenu,
+        SidebarMenuButton,
+        SidebarMenuItem,
+        SidebarProvider,
+        SidebarSeparator,
+        SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { defaultNavigation } from "@/config/ui";
+import { authClient } from "@/lib/auth-client";
+import { getUserRoles } from "@/lib/session";
 import { HeaderNavWrapper } from "./HeaderNavWrapper";
 
 export type NavItem = {
-	title: string;
-	href: string;
-	icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+        title: string;
+        href: string;
+        icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
 };
 
 export type NavGroup = {
-	label: string;
-	items: NavItem[];
+        label: string;
+        items: NavItem[];
 };
 
 export type Crumb = { label: string; href?: string; current?: boolean };
 
+const WORKSPACE_ITEMS: NavItem[] = [
+        { title: "Overview", href: "/", icon: LayoutDashboard },
+        { title: "Events", href: "/events", icon: CalendarDays },
+        { title: "Account settings", href: "/account/settings", icon: Settings },
+];
+
+function mergeNavigation(baseGroups: NavGroup[], workspaceItems: NavItem[]): NavGroup[] {
+        const seen = new Set<string>();
+        const dedupe = (items: NavItem[]) =>
+                items.filter((item) => {
+                        if (seen.has(item.href)) return false;
+                        seen.add(item.href);
+                        return true;
+                });
+
+        const merged: NavGroup[] = [
+                {
+                        label: "Workspace",
+                        items: dedupe([...workspaceItems]),
+                },
+        ];
+
+        for (const group of baseGroups) {
+                const filteredItems = dedupe([...group.items]);
+                if (filteredItems.length > 0) {
+                        merged.push({ ...group, items: filteredItems });
+                }
+        }
+
+        return merged;
+}
+
 export default function AppShell({
-	appName = "calendar sync",
-	consoleName = "Admin Console",
-	navigation = defaultNavigation,
-	breadcrumbs = [
-		{ label: "Admin", href: "/" },
-		{ label: "Overview", current: true },
-	],
-	headerRight,
-	children,
+        appName = "calendar sync",
+        consoleName = "Admin Console",
+        navigation = defaultNavigation,
+        breadcrumbs = [
+                { label: "Admin", href: "/" },
+                { label: "Overview", current: true },
+        ],
+        headerRight,
+        children,
 }: {
-	appName?: string;
-	consoleName?: string;
-	navigation?: NavGroup[];
-	breadcrumbs?: Crumb[];
-	headerRight?: React.ReactNode;
-	children: React.ReactNode;
+        appName?: string;
+        consoleName?: string;
+        navigation?: NavGroup[];
+        breadcrumbs?: Crumb[];
+        headerRight?: React.ReactNode;
+        children: React.ReactNode;
 }) {
-	const pathname = usePathname();
-	return (
-		<SidebarProvider>
-			<div className="flex min-h-screen w-full bg-muted/30">
-				<Sidebar>
-					<SidebarHeader className="gap-3">
-						<div>
-							<p className="font-semibold text-muted-foreground text-sm uppercase tracking-wide">
-								{appName}
-							</p>
-							<p className="font-semibold text-lg text-sidebar-foreground">
-								{consoleName}
-							</p>
-						</div>
-					</SidebarHeader>
-					<SidebarSeparator />
-					<SidebarContent>
-						{navigation.map((group) => (
-							<SidebarGroup key={group.label}>
-								<SidebarGroupLabel>{group.label}</SidebarGroupLabel>
-								<SidebarGroupContent>
-									<SidebarMenu>
-										{group.items.map((item) => (
-											<SidebarMenuItem key={item.title}>
-												<SidebarMenuButton
-													asChild
-													isActive={pathname.startsWith(item.href)}
-												>
-													<Link
-														href={item.href as any}
-														className="flex items-center gap-2"
-													>
-														{item.icon ? (
-															<item.icon className="size-4" />
-														) : null}
-														<span>{item.title}</span>
-													</Link>
-												</SidebarMenuButton>
-											</SidebarMenuItem>
-										))}
-									</SidebarMenu>
-								</SidebarGroupContent>
-							</SidebarGroup>
-						))}
-					</SidebarContent>
-					<SidebarFooter>
-						<OrganizationSwitcher className="bg-primary-foreground text-accent-primary hover:bg-accent-primary-foreground/80 hover:text-primary" />
-					</SidebarFooter>
-				</Sidebar>
+        const pathname = usePathname();
+        const { data: session } = authClient.useSession();
+        const roles = React.useMemo(() => getUserRoles(session), [session]);
+        const isAdmin = roles.includes("admin");
 
-				<SidebarInset>
-					<HeaderNavWrapper>
-						<SidebarTrigger className="md:hidden" />
-						<div className="flex flex-1 items-center justify-between gap-4">
-							<Breadcrumb>
-								<BreadcrumbList>
-									{breadcrumbs.map((c, idx) => (
-										<React.Fragment key={idx}>
-											<BreadcrumbItem>
-												{c.current ? (
-													<BreadcrumbPage>{c.label}</BreadcrumbPage>
-												) : (
-													<BreadcrumbLink asChild>
-														<Link href={c.href || ("#" as any)}>{c.label}</Link>
-													</BreadcrumbLink>
-												)}
-											</BreadcrumbItem>
-											{idx < breadcrumbs.length - 1 && <BreadcrumbSeparator />}
-										</React.Fragment>
-									))}
-								</BreadcrumbList>
-							</Breadcrumb>
+        const baseNavigation = navigation ?? defaultNavigation;
 
-							<div className="flex items-center gap-2">{headerRight}</div>
-						</div>
-					</HeaderNavWrapper>
+        const navigationWithWorkspace = React.useMemo(
+                () => mergeNavigation(baseNavigation, WORKSPACE_ITEMS),
+                [baseNavigation],
+        );
 
-					<main className="flex flex-1 flex-col gap-8 px-6 py-10">
-						{children}
-					</main>
-				</SidebarInset>
-			</div>
-		</SidebarProvider>
-	);
+        const filteredNavigation = React.useMemo(() => {
+                if (isAdmin) {
+                        return navigationWithWorkspace;
+                }
+
+                return navigationWithWorkspace
+                        .map((group) => ({
+                                ...group,
+                                items: group.items.filter((item) => !item.href.startsWith("/admin")),
+                        }))
+                        .filter((group) => group.items.length > 0);
+        }, [isAdmin, navigationWithWorkspace]);
+
+        const navigationToRender = filteredNavigation.length
+                ? filteredNavigation
+                : navigationWithWorkspace;
+
+        return (
+                <SidebarProvider>
+                        <div className="flex min-h-screen w-full bg-muted/30">
+                                <Sidebar>
+                                        <SidebarHeader className="gap-3">
+                                                <div>
+                                                        <p className="font-semibold text-muted-foreground text-sm uppercase tracking-wide">
+                                                                {appName}
+                                                        </p>
+                                                        <p className="font-semibold text-lg text-sidebar-foreground">
+                                                                {consoleName}
+                                                        </p>
+                                                </div>
+                                        </SidebarHeader>
+                                        <SidebarSeparator />
+                                        <SidebarContent>
+                                                {navigationToRender.map((group) => (
+                                                        <SidebarGroup key={group.label}>
+                                                                <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
+                                                                <SidebarGroupContent>
+                                                                        <SidebarMenu>
+                                                                                {group.items.map((item) => (
+                                                                                        <SidebarMenuItem key={item.title}>
+                                                                                                <SidebarMenuButton
+                                                                                                        asChild
+                                                                                                        isActive={pathname.startsWith(item.href)}
+                                                                                                >
+                                                                                                        <Link
+                                                                                                                href={item.href as any}
+                                                                                                                className="flex items-center gap-2"
+                                                                                                        >
+                                                                                                                {item.icon ? (
+                                                                                                                        <item.icon className="size-4" />
+                                                                                                                ) : null}
+                                                                                                                <span>{item.title}</span>
+                                                                                                        </Link>
+                                                                                                </SidebarMenuButton>
+                                                                                        </SidebarMenuItem>
+                                                                                ))}
+                                                                        </SidebarMenu>
+                                                                </SidebarGroupContent>
+                                                        </SidebarGroup>
+                                                ))}
+                                        </SidebarContent>
+                                        <SidebarFooter>
+                                                <OrganizationSwitcher className="bg-primary-foreground text-accent-primary hover:bg-accent-primary-foreground/80 hover:text-primary" />
+                                        </SidebarFooter>
+                                </Sidebar>
+
+                                <SidebarInset>
+                                        <HeaderNavWrapper>
+                                                <SidebarTrigger className="md:hidden" />
+                                                <div className="flex flex-1 items-center justify-between gap-4">
+                                                        <Breadcrumb>
+                                                                <BreadcrumbList>
+                                                                        {breadcrumbs.map((c, idx) => (
+                                                                                <React.Fragment key={idx}>
+                                                                                        <BreadcrumbItem>
+                                                                                                {c.current ? (
+                                                                                                        <BreadcrumbPage>{c.label}</BreadcrumbPage>
+                                                                                                ) : (
+                                                                                                        <BreadcrumbLink asChild>
+                                                                                                                <Link href={c.href || ("#" as any)}>{c.label}</Link>
+                                                                                                        </BreadcrumbLink>
+                                                                                                )}
+                                                                                        </BreadcrumbItem>
+                                                                                        {idx < breadcrumbs.length - 1 && <BreadcrumbSeparator />}
+                                                                                </React.Fragment>
+                                                                        ))}
+                                                                </BreadcrumbList>
+                                                        </Breadcrumb>
+
+                                                        <div className="flex items-center gap-2">{headerRight}</div>
+                                                </div>
+                                        </HeaderNavWrapper>
+
+                                        <main className="flex flex-1 flex-col gap-8 px-6 py-10">
+                                                {children}
+                                        </main>
+                                </SidebarInset>
+                        </div>
+                </SidebarProvider>
+        );
 }

--- a/apps/server/src/lib/calendar-links.ts
+++ b/apps/server/src/lib/calendar-links.ts
@@ -1,0 +1,330 @@
+const URL_DESCRIPTION_LIMIT = 900;
+const DEFAULT_DURATION_MS = 60 * 60 * 1000;
+
+export type CalendarEventInput = {
+  id: string;
+  title: string;
+  startAt: string | Date;
+  endAt?: string | Date | null;
+  description?: string | null;
+  location?: string | null;
+  url?: string | null;
+  metadata?: Record<string, unknown> | null | undefined;
+};
+
+export function getEventTimezone(event: CalendarEventInput): string | undefined {
+  const metadata = event.metadata;
+  if (!metadata || typeof metadata !== "object") {
+    return undefined;
+  }
+
+  const candidates = [
+    (metadata as Record<string, unknown>).timezone,
+    (metadata as Record<string, unknown>).timeZone,
+    (metadata as Record<string, unknown>).tz,
+  ];
+
+  const timezone = candidates.find(
+    (value): value is string => typeof value === "string" && value.trim().length > 0,
+  );
+
+  if (!timezone) return undefined;
+
+  try {
+    // Throws if the timezone identifier is invalid
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format(new Date());
+    return timezone;
+  } catch {
+    return undefined;
+  }
+}
+
+function toDate(value: string | Date): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+function getSafeEndDate(start: Date, potentialEnd?: Date | null): Date {
+  if (!potentialEnd) {
+    return new Date(start.getTime() + DEFAULT_DURATION_MS);
+  }
+
+  if (Number.isNaN(potentialEnd.getTime())) {
+    return new Date(start.getTime() + DEFAULT_DURATION_MS);
+  }
+
+  if (potentialEnd.getTime() <= start.getTime()) {
+    return new Date(start.getTime() + DEFAULT_DURATION_MS);
+  }
+
+  return potentialEnd;
+}
+
+type DateParts = {
+  year: string;
+  month: string;
+  day: string;
+  hour: string;
+  minute: string;
+  second: string;
+};
+
+function getDateParts(date: Date, timeZone?: string): DateParts | null {
+  try {
+    const formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    });
+
+    const parts = formatter.formatToParts(date).reduce<Record<string, string>>(
+      (acc, part) => {
+        if (part.type !== "literal") {
+          acc[part.type] = part.value;
+        }
+        return acc;
+      },
+      {},
+    );
+
+    const { year, month, day, hour, minute, second } = parts;
+    if (!year || !month || !day || !hour || !minute || !second) {
+      return null;
+    }
+
+    return { year, month, day, hour, minute, second };
+  } catch {
+    return null;
+  }
+}
+
+function formatLocalDateTime(date: Date, timeZone: string): string | null {
+  const parts = getDateParts(date, timeZone);
+  if (!parts) return null;
+  return `${parts.year}${parts.month}${parts.day}T${parts.hour}${parts.minute}${parts.second}`;
+}
+
+function formatLocalDate(date: Date, timeZone: string): string | null {
+  const parts = getDateParts(date, timeZone);
+  if (!parts) return null;
+  return `${parts.year}${parts.month}${parts.day}`;
+}
+
+function formatUtcBasic(date: Date): string {
+  return date.toISOString().replace(/[-:]/g, "").slice(0, 15) + "Z";
+}
+
+function formatOutlookDate(date: Date, timeZone?: string): string {
+  if (!timeZone) {
+    return date.toISOString().slice(0, 19);
+  }
+
+  const parts = getDateParts(date, timeZone);
+  if (!parts) {
+    return date.toISOString().slice(0, 19);
+  }
+
+  return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}`;
+}
+
+function truncateDescription(description: string): string {
+  if (description.length <= URL_DESCRIPTION_LIMIT) {
+    return description;
+  }
+  return `${description.slice(0, URL_DESCRIPTION_LIMIT - 1)}…`;
+}
+
+function escapeText(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/,/g, "\\,").replace(/;/g, "\\;");
+}
+
+function safeLocation(event: CalendarEventInput): string {
+  return event.location ? event.location : "";
+}
+
+function appendLink(details: string, url?: string | null): string {
+  if (!url) return details;
+  const trimmed = details.trimEnd();
+  const separator = trimmed.length > 0 ? "\n\n" : "";
+  return `${trimmed}${separator}More info: ${url}`;
+}
+
+export function getGoogleCalendarUrl(event: CalendarEventInput): string {
+  const base = "https://calendar.google.com/calendar/render?action=TEMPLATE";
+  const start = toDate(event.startAt);
+  const end = getSafeEndDate(start, event.endAt ? toDate(event.endAt) : undefined);
+  const timezone = getEventTimezone(event);
+  const description = appendLink(event.description ?? "", event.url ?? undefined);
+  const truncated = truncateDescription(description);
+
+  let dateParam: string;
+  const query: string[] = [
+    `text=${encodeURIComponent(event.title)}`,
+    `details=${encodeURIComponent(truncated)}`,
+    `location=${encodeURIComponent(safeLocation(event))}`,
+  ];
+
+  if (timezone) {
+    const startLocal = formatLocalDateTime(start, timezone);
+    const endLocal = formatLocalDateTime(end, timezone);
+    if (startLocal && endLocal) {
+      dateParam = `${startLocal}/${endLocal}`;
+      query.push(`dates=${dateParam}`);
+      query.push(`ctz=${encodeURIComponent(timezone)}`);
+      return `${base}&${query.join("&")}`;
+    }
+  }
+
+  dateParam = `${formatUtcBasic(start)}/${formatUtcBasic(end)}`;
+  query.push(`dates=${dateParam}`);
+  return `${base}&${query.join("&")}`;
+}
+
+export function getOutlookCalendarUrl(event: CalendarEventInput): string {
+  const base = "https://outlook.office.com/calendar/0/deeplink/compose";
+  const start = toDate(event.startAt);
+  const end = getSafeEndDate(start, event.endAt ? toDate(event.endAt) : undefined);
+  const timezone = getEventTimezone(event);
+  const description = appendLink(event.description ?? "", event.url ?? undefined);
+  const truncated = truncateDescription(description);
+
+  const query = [
+    "path=%2Fcalendar%2Faction%2Fcompose",
+    "rru=addevent",
+    `subject=${encodeURIComponent(event.title)}`,
+    `startdt=${encodeURIComponent(formatOutlookDate(start, timezone))}`,
+    `enddt=${encodeURIComponent(formatOutlookDate(end, timezone))}`,
+    `body=${encodeURIComponent(truncated)}`,
+    `location=${encodeURIComponent(safeLocation(event))}`,
+  ];
+
+  return `${base}?${query.join("&")}`;
+}
+
+export function getYahooCalendarUrl(event: CalendarEventInput): string {
+  const base = "https://calendar.yahoo.com/?v=60&view=d&type=20";
+  const start = toDate(event.startAt);
+  const end = getSafeEndDate(start, event.endAt ? toDate(event.endAt) : undefined);
+  const description = appendLink(event.description ?? "", event.url ?? undefined);
+  const truncated = truncateDescription(description);
+
+  const durationMs = Math.max(end.getTime() - start.getTime(), DEFAULT_DURATION_MS);
+  const durationMinutes = Math.round(durationMs / 60000);
+  const hours = Math.floor(durationMinutes / 60);
+  const minutes = durationMinutes % 60;
+  const cappedHours = Math.min(hours, 99);
+  const durationString = `${String(cappedHours).padStart(2, "0")}${String(minutes).padStart(2, "0")}`;
+
+  const query = [
+    `title=${encodeURIComponent(event.title)}`,
+    `st=${formatUtcBasic(start)}`,
+    `dur=${durationString}`,
+    `desc=${encodeURIComponent(truncated)}`,
+    `in_loc=${encodeURIComponent(safeLocation(event))}`,
+  ];
+
+  return `${base}&${query.join("&")}`;
+}
+
+export function buildICS(event: CalendarEventInput): string {
+  const start = toDate(event.startAt);
+  const end = getSafeEndDate(start, event.endAt ? toDate(event.endAt) : undefined);
+  const timezone = getEventTimezone(event);
+  const description = appendLink(event.description ?? "", event.url ?? undefined);
+
+  const uid = `${event.id}@calendarsync.local`;
+  const dtstamp = formatUtcBasic(new Date());
+  const lines: string[] = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//CalendarSync//EN",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    "BEGIN:VEVENT",
+    `UID:${uid}`,
+    `SUMMARY:${escapeText(event.title)}`,
+  ];
+
+  if (timezone) {
+    const startLocal = formatLocalDateTime(start, timezone);
+    const endLocal = formatLocalDateTime(end, timezone);
+    if (startLocal && endLocal) {
+      lines.push(`DTSTART;TZID=${timezone}:${startLocal}`);
+      lines.push(`DTEND;TZID=${timezone}:${endLocal}`);
+      lines.push(`X-WR-TIMEZONE:${timezone}`);
+    } else {
+      lines.push(`DTSTART:${formatUtcBasic(start)}`);
+      lines.push(`DTEND:${formatUtcBasic(end)}`);
+    }
+  } else {
+    lines.push(`DTSTART:${formatUtcBasic(start)}`);
+    lines.push(`DTEND:${formatUtcBasic(end)}`);
+  }
+
+  lines.push(`DTSTAMP:${dtstamp}`);
+  lines.push(`DESCRIPTION:${escapeText(description)}`);
+
+  if (event.location) {
+    lines.push(`LOCATION:${escapeText(event.location)}`);
+  }
+
+  if (event.url) {
+    lines.push(`URL:${escapeText(event.url)}`);
+  }
+
+  lines.push("END:VEVENT");
+  lines.push("END:VCALENDAR");
+
+  return lines.join("\r\n");
+}
+
+function toSafeFileName(title: string, fallback: string): string {
+  const normalized = title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  const base = normalized.length > 0 ? normalized : fallback;
+  return `${base}.ics`;
+}
+
+export function downloadICS(event: CalendarEventInput, fileName?: string) {
+  const ics = buildICS(event);
+  const blob = new Blob([ics], { type: "text/calendar;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = fileName ?? toSafeFileName(event.title, `event-${event.id}`);
+  anchor.rel = "noopener";
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+export function formatEventDateRange(
+  event: CalendarEventInput,
+  formatter: (start: Date, end: Date, timeZone?: string) => string,
+): string {
+  const start = toDate(event.startAt);
+  const end = getSafeEndDate(start, event.endAt ? toDate(event.endAt) : undefined);
+  const timezone = getEventTimezone(event);
+  return formatter(start, end, timezone);
+}
+
+export function formatDateBadge(event: CalendarEventInput): string {
+  const timezone = getEventTimezone(event);
+  const start = toDate(event.startAt);
+  if (timezone) {
+    const dateOnly = formatLocalDate(start, timezone);
+    if (dateOnly) {
+      return `${dateOnly.slice(0, 4)}-${dateOnly.slice(4, 6)}-${dateOnly.slice(6, 8)}`;
+    }
+  }
+  return start.toISOString().split("T")[0];
+}

--- a/apps/server/src/lib/session.ts
+++ b/apps/server/src/lib/session.ts
@@ -1,0 +1,37 @@
+export type SessionLike =
+  | (Record<string, unknown> & {
+      user?:
+        | (Record<string, unknown> & {
+            role?: string | null;
+            roles?: string[] | null;
+          })
+        | null;
+    })
+  | null
+  | undefined;
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+export function getUserRoles(session: SessionLike): string[] {
+  if (!session) return [];
+  const user = session.user;
+  if (!user || typeof user !== "object") return [];
+
+  const possibleRoles = (user as { roles?: unknown }).roles;
+  if (isStringArray(possibleRoles) && possibleRoles.length > 0) {
+    return possibleRoles;
+  }
+
+  const singleRole = (user as { role?: unknown }).role;
+  if (typeof singleRole === "string" && singleRole.length > 0) {
+    return [singleRole];
+  }
+
+  return [];
+}
+
+export function isAdminSession(session: SessionLike): boolean {
+  return getUserRoles(session).includes("admin");
+}

--- a/apps/server/src/types/events.ts
+++ b/apps/server/src/types/events.ts
@@ -1,0 +1,7 @@
+import type { inferRouterOutputs } from "@trpc/server";
+
+import type { AppRouter } from "@/routers";
+
+type RouterOutputs = inferRouterOutputs<AppRouter>;
+
+export type UpcomingEvent = RouterOutputs["events"]["listRecentForUser"][number];

--- a/docs/time-handling.md
+++ b/docs/time-handling.md
@@ -1,0 +1,12 @@
+# Calendar link time handling
+
+- Client-side calendar helpers (`apps/server/src/lib/calendar-links.ts`) inspect each event's metadata for `timezone`, `timeZone`, or `tz`. When a valid IANA timezone is present, links use local date/times together with `ctz` (Google) or `TZID` (ICS). Otherwise, the helpers fall back to the stored UTC timestamp (`...Z`) without inventing defaults.
+- End times default to one hour after the start only when no `endAt` exists or it is invalid/earlier than the start. This avoids zero-length calendar entries while staying predictable.
+- URL query parameters truncate long descriptions to 900 characters (with an ellipsis) so Google/Yahoo/Outlook links remain reliable. The generated ICS file always contains the full description plus the source URL, so importing the file preserves the complete context.
+- Date filtering in the `/events` view relies on `formatDateBadge`, which prefers the event’s own timezone (if one exists) to derive a `YYYY-MM-DD` key. Without a timezone, the UTC ISO date is used.
+- ICS files add `X-WR-TIMEZONE` only when the event provides a trustworthy timezone. Location and URL fields are escaped per RFC 5545 to keep special characters safe during import.
+
+Known edge cases:
+
+- All-day events aren’t specially handled because the current event payloads do not expose an `isAllDay` flag. If that metadata becomes available, Google/ICS helpers can be extended to emit `VALUE=DATE` entries.
+- When providers send ambiguous or invalid timezone strings, helpers silently fall back to UTC rather than throwing errors, ensuring link generation still succeeds.


### PR DESCRIPTION
## Summary
- add client-side calendar helpers for Google, Outlook, Yahoo, and ICS exports
- create a reusable event card and a new /events user page with soft styling and filters
- update the shared app shell to surface workspace navigation while hiding admin-only links for non-admin sessions
- document calendar time-handling behavior and reuse a shared role extractor

## Testing
- `bun run --filter server build` *(fails: fonts could not be fetched in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_b_68d64fdf1af08327bcbbc95f199c15a8