### PR TITLE
Add standalone organizations page

### DIFF
--- a/apps/server/src/app/(site)/organizations/page.tsx
+++ b/apps/server/src/app/(site)/organizations/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Building2 } from "lucide-react";
+import * as React from "react";
+import Link from "next/link";
+import { RedirectToSignIn } from "@daveyplate/better-auth-ui";
+
+import AppShell from "@/components/layout/AppShell";
+import { OrganizationsOverview } from "@/components/organizations/OrganizationsOverview";
+import { UserAvatar } from "@/components/UserAvatar";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+export default function OrganizationsPage() {
+  return (
+    <AppShell
+      breadcrumbs={[
+        { label: "Home", href: "/" },
+        { label: "Organizations", current: true },
+      ]}
+      headerRight={<UserAvatar />}
+    >
+      <RedirectToSignIn />
+
+      <section className="space-y-6">
+        <Card className="space-y-3 rounded-3xl border-none bg-gradient-to-r from-primary/10 via-primary/5 to-transparent p-8 text-foreground shadow-sm">
+          <div className="flex flex-col gap-2">
+            <p className="text-muted-foreground text-sm">Workspace directory</p>
+            <h1 className="font-semibold text-3xl tracking-tight sm:text-4xl">
+              Explore your organizations
+            </h1>
+            <p className="max-w-2xl text-muted-foreground text-sm">
+              Review the teams you belong to and discover new ones tailored to your interests. Join in a click and keep your calendar aligned.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3 text-muted-foreground text-sm">
+            <span className="inline-flex items-center gap-2">
+              <Building2 className="size-4" aria-hidden />
+              Manage memberships and find new collaborators
+            </span>
+            <Button variant="ghost" className="h-auto px-0 text-xs" asChild>
+              <Link href="/account/settings">Adjust notification settings</Link>
+            </Button>
+          </div>
+        </Card>
+      </section>
+
+      <OrganizationsOverview
+        title="Organizations"
+        description="Search, filter, and join workspaces that matter to you."
+        className="mt-6"
+      />
+    </AppShell>
+  );
+}

--- a/apps/server/src/components/layout/AppShell.tsx
+++ b/apps/server/src/components/layout/AppShell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { OrganizationSwitcher } from "@daveyplate/better-auth-ui";
-import { CalendarDays, LayoutDashboard, Settings } from "lucide-react";
+import { Building2, CalendarDays, LayoutDashboard, Settings } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import React from "react";
@@ -51,6 +51,7 @@ export type Crumb = { label: string; href?: string; current?: boolean };
 const WORKSPACE_ITEMS: NavItem[] = [
   { title: "Overview", href: "/", icon: LayoutDashboard },
   { title: "Events", href: "/events", icon: CalendarDays },
+  { title: "Organizations", href: "/organizations", icon: Building2 },
   { title: "Account settings", href: "/account/settings", icon: Settings },
 ];
 

--- a/apps/server/src/components/organizations/OrganizationsOverview.tsx
+++ b/apps/server/src/components/organizations/OrganizationsOverview.tsx
@@ -1,0 +1,584 @@
+"use client";
+
+import {
+  type InfiniteData,
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import type { inferRouterOutputs } from "@trpc/server";
+import * as React from "react";
+import { AlertCircle, CalendarDays, Loader2, Users } from "lucide-react";
+import { format } from "date-fns";
+import Link from "next/link";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { orgsKeys } from "@/lib/query-keys/orgs";
+import { orgsApi } from "@/lib/trpc-client";
+import type { AppRouter } from "@/routers";
+import { cn } from "@/lib/utils";
+
+const ORGANIZATION_PAGE_SIZE = 6;
+
+type RouterOutputs = inferRouterOutputs<AppRouter>;
+type OrgListResult = RouterOutputs["orgs"]["listForUser"];
+type JoinedPage = Extract<OrgListResult, { segment: "joined" }>;
+type DiscoverPage = Extract<OrgListResult, { segment: "discover" }>;
+type JoinedOrganization = JoinedPage["items"][number];
+type DiscoverOrganization = DiscoverPage["items"][number];
+
+type JoinVariables = {
+  organizationId: string;
+  optimisticOrg: DiscoverOrganization;
+};
+type JoinContext = {
+  previousJoined?: InfiniteData<JoinedPage>;
+  previousDiscover?: InfiniteData<DiscoverPage>;
+};
+
+export type OrganizationsOverviewProps = {
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  searchPlaceholder?: string;
+  className?: string;
+};
+
+export function OrganizationsOverview({
+  title = "Organizations",
+  description = "Manage the workspaces you already belong to or discover new ones to follow.",
+  searchPlaceholder = "Search organizations…",
+  className,
+}: OrganizationsOverviewProps) {
+  const [search, setSearch] = React.useState("");
+  const deferredSearch = React.useDeferredValue(search);
+
+  const joinedFilters = React.useMemo(
+    () => ({
+      segment: "joined" as const,
+      search:
+        deferredSearch.trim().length > 0 ? deferredSearch.trim() : undefined,
+      limit: ORGANIZATION_PAGE_SIZE,
+      sort: "recent" as const,
+    }),
+    [deferredSearch],
+  );
+
+  const discoverFilters = React.useMemo(
+    () => ({
+      segment: "discover" as const,
+      search:
+        deferredSearch.trim().length > 0 ? deferredSearch.trim() : undefined,
+      limit: ORGANIZATION_PAGE_SIZE,
+      sort: "name-asc" as const,
+    }),
+    [deferredSearch],
+  );
+
+  const joinedKey = React.useMemo(
+    () =>
+      orgsKeys.list({
+        segment: joinedFilters.segment,
+        search: joinedFilters.search ?? null,
+        limit: joinedFilters.limit ?? null,
+        sort: joinedFilters.sort ?? null,
+      }),
+    [joinedFilters],
+  );
+
+  const discoverKey = React.useMemo(
+    () =>
+      orgsKeys.list({
+        segment: discoverFilters.segment,
+        search: discoverFilters.search ?? null,
+        limit: discoverFilters.limit ?? null,
+        sort: discoverFilters.sort ?? null,
+      }),
+    [discoverFilters],
+  );
+
+  const joinedQuery = useInfiniteQuery<JoinedPage>({
+    queryKey: joinedKey,
+    initialPageParam: 1,
+    queryFn: ({ pageParam }) =>
+      orgsApi.listForUser({
+        ...joinedFilters,
+        page: typeof pageParam === "number" ? pageParam : 1,
+      }),
+    getNextPageParam: (lastPage) => lastPage.nextPage ?? undefined,
+  });
+
+  const discoverQuery = useInfiniteQuery<DiscoverPage>({
+    queryKey: discoverKey,
+    initialPageParam: 1,
+    queryFn: ({ pageParam }) =>
+      orgsApi.listForUser({
+        ...discoverFilters,
+        page: typeof pageParam === "number" ? pageParam : 1,
+      }),
+    getNextPageParam: (lastPage) => lastPage.nextPage ?? undefined,
+  });
+
+  const queryClient = useQueryClient();
+  const joinMutation = useJoinOrganizationMutation({
+    queryClient,
+    joinedKey,
+    discoverKey,
+    joinedFilters,
+  });
+
+  const handleJoin = React.useCallback(
+    (organization: DiscoverOrganization) => {
+      joinMutation.mutate({
+        organizationId: organization.id,
+        optimisticOrg: organization,
+      });
+    },
+    [joinMutation],
+  );
+
+  const joinedItems = React.useMemo(
+    () => joinedQuery.data?.pages.flatMap((page) => page.items) ?? [],
+    [joinedQuery.data],
+  );
+  const discoverItems = React.useMemo(
+    () => discoverQuery.data?.pages.flatMap((page) => page.items) ?? [],
+    [discoverQuery.data],
+  );
+
+  return (
+    <section className={cn("space-y-4", className)}>
+      {title ? (
+        <header className="space-y-1">
+          <h2 className="font-semibold text-2xl tracking-tight">{title}</h2>
+          {description ? (
+            <p className="text-muted-foreground text-sm">{description}</p>
+          ) : null}
+        </header>
+      ) : null}
+
+      <Tabs defaultValue="joined" className="space-y-4">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <TabsList>
+            <TabsTrigger value="joined">Joined</TabsTrigger>
+            <TabsTrigger value="discover">Discover</TabsTrigger>
+          </TabsList>
+          <Input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder={searchPlaceholder}
+            className="md:max-w-xs"
+            aria-label="Search organizations"
+          />
+        </div>
+        <TabsContent value="joined" className="space-y-4">
+          {joinedQuery.isLoading ? (
+            <OrganizationSkeletonGrid />
+          ) : joinedQuery.isError ? (
+            <ErrorState
+              message="We couldn’t load your organizations."
+              onRetry={joinedQuery.refetch}
+            />
+          ) : joinedItems.length === 0 ? (
+            <EmptyState
+              title="No organizations yet"
+              description="You haven’t joined any organizations. Discover new workspaces to collaborate with."
+            />
+          ) : (
+            <React.Fragment>
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {joinedItems.map((org) => (
+                  <JoinedOrganizationCard key={org.id} organization={org} />
+                ))}
+              </div>
+              {joinedQuery.hasNextPage ? (
+                <Button
+                  onClick={() => joinedQuery.fetchNextPage()}
+                  disabled={joinedQuery.isFetchingNextPage}
+                >
+                  {joinedQuery.isFetchingNextPage ? "Loading…" : "Load more"}
+                </Button>
+              ) : null}
+            </React.Fragment>
+          )}
+        </TabsContent>
+        <TabsContent value="discover" className="space-y-4">
+          {discoverQuery.isLoading ? (
+            <OrganizationSkeletonGrid />
+          ) : discoverQuery.isError ? (
+            <ErrorState
+              message="We couldn’t load suggested organizations."
+              onRetry={discoverQuery.refetch}
+            />
+          ) : discoverItems.length === 0 ? (
+            <EmptyState
+              title="Nothing to discover"
+              description="You’re already part of every organization that matches your filters."
+            />
+          ) : (
+            <React.Fragment>
+              {joinMutation.isError ? (
+                <Alert variant="destructive">
+                  <AlertCircle className="size-4" />
+                  <AlertTitle>Join failed</AlertTitle>
+                  <AlertDescription>
+                    Something went wrong while joining the organization. Please
+                    try again.
+                  </AlertDescription>
+                </Alert>
+              ) : null}
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {discoverItems.map((org) => (
+                  <DiscoverOrganizationCard
+                    key={org.id}
+                    organization={org}
+                    onJoin={handleJoin}
+                    isJoining={
+                      joinMutation.isPending &&
+                      joinMutation.variables?.organizationId === org.id
+                    }
+                  />
+                ))}
+              </div>
+              {discoverQuery.hasNextPage ? (
+                <Button
+                  onClick={() => discoverQuery.fetchNextPage()}
+                  disabled={discoverQuery.isFetchingNextPage}
+                >
+                  {discoverQuery.isFetchingNextPage ? "Loading…" : "Load more"}
+                </Button>
+              ) : null}
+            </React.Fragment>
+          )}
+        </TabsContent>
+      </Tabs>
+    </section>
+  );
+}
+
+function useJoinOrganizationMutation({
+  queryClient,
+  joinedKey,
+  discoverKey,
+  joinedFilters,
+}: {
+  queryClient: ReturnType<typeof useQueryClient>;
+  joinedKey: ReturnType<typeof orgsKeys.list>;
+  discoverKey: ReturnType<typeof orgsKeys.list>;
+  joinedFilters: {
+    segment: "joined";
+    limit: number;
+    sort: JoinedPage["sort"];
+  } & Record<string, unknown>;
+}) {
+  return useMutation<JoinedOrganization, unknown, JoinVariables, JoinContext>({
+    mutationFn: ({ organizationId }) =>
+      orgsApi.join({ organizationId }),
+    onMutate: async (variables) => {
+      await queryClient.cancelQueries({ queryKey: joinedKey });
+      await queryClient.cancelQueries({ queryKey: discoverKey });
+
+      const previousJoined = queryClient.getQueryData<InfiniteData<JoinedPage>>(
+        joinedKey,
+      );
+      const previousDiscover =
+        queryClient.getQueryData<InfiniteData<DiscoverPage>>(discoverKey);
+
+      const optimisticJoined = variables.optimisticOrg;
+
+      queryClient.setQueryData<InfiniteData<JoinedPage>>(
+        joinedKey,
+        (existing) => {
+          if (!existing) {
+            return {
+              pages: [
+                {
+                  items: [optimisticJoined],
+                  segment: joinedFilters.segment,
+                  page: 1,
+                  limit: joinedFilters.limit,
+                  sort: joinedFilters.sort,
+                  nextPage: null,
+                },
+              ],
+              pageParams: [1],
+            } satisfies InfiniteData<JoinedPage>;
+          }
+
+          const [firstPage, ...restPages] = existing.pages;
+          const updatedFirstPage: JoinedPage = {
+            ...firstPage,
+            items: [
+              optimisticJoined,
+              ...firstPage.items.filter((item) => item.id !== optimisticJoined.id),
+            ],
+          };
+
+          return {
+            ...existing,
+            pages: [
+              updatedFirstPage,
+              ...restPages.map((page) => ({
+                ...page,
+                items: page.items.filter(
+                  (item) => item.id !== optimisticJoined.id,
+                ),
+              })),
+            ],
+          };
+        },
+      );
+
+      queryClient.setQueryData<InfiniteData<DiscoverPage>>(
+        discoverKey,
+        (existing) => {
+          if (!existing) return existing;
+          return {
+            ...existing,
+            pages: existing.pages.map((page) => ({
+              ...page,
+              items: page.items.filter(
+                (item) => item.id !== variables.optimisticOrg.id,
+              ),
+            })),
+          };
+        },
+      );
+
+      return { previousJoined, previousDiscover } satisfies JoinContext;
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousJoined) {
+        queryClient.setQueryData(joinedKey, context.previousJoined);
+      }
+      if (context?.previousDiscover) {
+        queryClient.setQueryData(discoverKey, context.previousDiscover);
+      }
+    },
+    onSuccess: (result) => {
+      queryClient.setQueryData<InfiniteData<JoinedPage>>(
+        joinedKey,
+        (existing) => {
+          if (!existing) {
+            return {
+              pages: [
+                {
+                  items: [result],
+                  segment: joinedFilters.segment,
+                  page: 1,
+                  limit: joinedFilters.limit,
+                  sort: joinedFilters.sort,
+                  nextPage: null,
+                },
+              ],
+              pageParams: [1],
+            } satisfies InfiniteData<JoinedPage>;
+          }
+
+          return {
+            ...existing,
+            pages: existing.pages.map((page, index) =>
+              index === 0
+                ? {
+                    ...page,
+                    items: [
+                      result,
+                      ...page.items.filter((item) => item.id !== result.id),
+                    ],
+                  }
+                : {
+                    ...page,
+                    items: page.items.filter((item) => item.id !== result.id),
+                  },
+            ),
+          };
+        },
+      );
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: joinedKey });
+      queryClient.invalidateQueries({ queryKey: discoverKey });
+    },
+  });
+}
+
+function OrganizationSkeletonGrid() {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <Card key={index} className="flex h-full flex-col">
+          <CardHeader className="space-y-3">
+            <Skeleton className="h-5 w-3/4" />
+            <Skeleton className="h-4 w-2/3" />
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Skeleton className="h-3 w-1/4" />
+            <Skeleton className="h-9 w-24" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function EmptyState({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="rounded-lg border border-dashed p-8 text-center">
+      <h3 className="font-semibold text-lg">{title}</h3>
+      <p className="mt-2 text-muted-foreground text-sm">{description}</p>
+    </div>
+  );
+}
+
+function ErrorState({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <Alert variant="destructive" className="flex flex-col gap-3 text-left">
+      <div className="flex items-center gap-2">
+        <AlertCircle className="size-4" />
+        <AlertTitle>Something went wrong</AlertTitle>
+      </div>
+      <AlertDescription className="space-y-3">
+        <p>{message}</p>
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          Try again
+        </Button>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+function JoinedOrganizationCard({
+  organization,
+}: {
+  organization: JoinedOrganization;
+}) {
+  const tagline =
+    getOrganizationTagline(organization.metadata) ??
+    "Stay in sync with upcoming activity.";
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader className="space-y-2">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-lg">{organization.name}</CardTitle>
+          <Badge variant="outline" className="uppercase text-xs">
+            {organization.role}
+          </Badge>
+        </div>
+        <CardDescription className="line-clamp-2">{tagline}</CardDescription>
+      </CardHeader>
+      <CardContent className="mt-auto space-y-3 text-sm text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <CalendarDays className="size-4" aria-hidden />
+          <span>
+            Joined {formatDate(organization.joinedAt ?? organization.createdAt)}
+          </span>
+        </div>
+        <Button asChild variant="ghost" size="sm" className="w-fit px-0">
+          <Link href={`/organizations/${organization.slug}` as any}>
+            Open workspace
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DiscoverOrganizationCard({
+  organization,
+  onJoin,
+  isJoining,
+}: {
+  organization: DiscoverOrganization;
+  onJoin: (org: DiscoverOrganization) => void;
+  isJoining: boolean;
+}) {
+  const tagline =
+    getOrganizationTagline(organization.metadata) ??
+    "Add this workspace to keep tabs on new events.";
+  const membersLabel = new Intl.NumberFormat().format(
+    organization.membersCount ?? 0,
+  );
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader className="space-y-2">
+        <CardTitle className="text-lg">{organization.name}</CardTitle>
+        <CardDescription className="line-clamp-2">{tagline}</CardDescription>
+      </CardHeader>
+      <CardContent className="mt-auto space-y-4 text-sm text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <Users className="size-4" aria-hidden />
+          <span>{membersLabel} members</span>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            onClick={() => onJoin(organization)}
+            disabled={isJoining}
+            aria-busy={isJoining}
+          >
+            {isJoining ? (
+              <React.Fragment>
+                <Loader2 className="mr-2 size-4 animate-spin" /> Joining…
+              </React.Fragment>
+            ) : (
+              "Join organization"
+            )}
+          </Button>
+          <Button asChild variant="outline">
+            <Link href={`/organizations/${organization.slug}` as any}>
+              View details
+            </Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function formatDate(date: string | Date | null | undefined) {
+  if (!date) return "Unknown";
+  const value = typeof date === "string" ? new Date(date) : date;
+  try {
+    return format(value, "MMM d, yyyy");
+  } catch {
+    return "Unknown";
+  }
+}
+
+function getOrganizationTagline(
+  metadata: Record<string, unknown> | null | undefined,
+) {
+  if (!metadata) return null;
+  const tagline = metadata.tagline;
+  if (typeof tagline === "string" && tagline.trim().length > 0) {
+    return tagline;
+  }
+  const description = metadata.description;
+  if (typeof description === "string" && description.trim().length > 0) {
+    return description;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a standalone organizations page that wraps the shared organizations overview inside the app shell
- extract the organizations dashboard tabs into a reusable OrganizationsOverview component and reuse it on the home dashboard
- expose the organizations workspace link in the AppShell navigation for all users

## Testing
- bun run check-types *(fails: No packages matched the filter)*

------
https://chatgpt.com/codex/tasks/task_b_68d66f3ef3e08327bade1a830435aa37