### PR TITLE
feat: add interactive events calendar view

### DIFF
--- a/apps/server/src/app/(site)/events/page.tsx
+++ b/apps/server/src/app/(site)/events/page.tsx
@@ -1,100 +1,24 @@
 "use client";
 
 import "@/styles/big-calendar.css";
+
 import * as React from "react";
-import { AlertCircle, Filter, Loader2, RefreshCw } from "lucide-react";
 import { RedirectToSignIn } from "@daveyplate/better-auth-ui";
 import { useQuery } from "@tanstack/react-query";
 
-import { EventCard } from "@/components/events/EventCard";
+import EventsCalendar from "@/components/events/EventsCalendar";
 import AppShell from "@/components/layout/AppShell";
 import { UserAvatar } from "@/components/UserAvatar";
-import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Skeleton } from "@/components/ui/skeleton";
 import { eventKeys } from "@/lib/query-keys/events";
 import { eventsApi } from "@/lib/trpc-client";
-import { formatDateBadge, getEventTimezone } from "@/lib/calendar-links";
-import type { UpcomingEvent } from "@/types/events";
-import TestCalendar from "@/components/TestCalendar";
 
-const EVENTS_LIMIT = 20;
+const EVENTS_FETCH_LIMIT = 500;
 
-function getEventDateKey(event: UpcomingEvent): string {
-  return formatDateBadge(event);
-}
 export default function EventsPage() {
-  const [search, setSearch] = React.useState("");
-  const [location, setLocation] = React.useState("all");
-  const [date, setDate] = React.useState("");
-
   const eventsQuery = useQuery({
-    queryKey: eventKeys.recentForUser({ limit: EVENTS_LIMIT }),
-    queryFn: () => eventsApi.listRecentForUser({ limit: EVENTS_LIMIT }),
+    queryKey: eventKeys.recentForUser({ limit: EVENTS_FETCH_LIMIT }),
+    queryFn: () => eventsApi.listRecentForUser({ limit: EVENTS_FETCH_LIMIT }),
   });
-
-  const events = eventsQuery.data ?? [];
-  const normalizedSearch = search.trim().toLowerCase();
-
-  const locationOptions = React.useMemo(() => {
-    const unique = new Map<string, string>();
-    for (const event of events) {
-      const label = event.location?.trim();
-      if (!label || label.length === 0) continue;
-      const key = label.toLowerCase();
-      if (!unique.has(key)) {
-        unique.set(key, label);
-      }
-    }
-    return Array.from(unique.entries())
-      .sort((a, b) => a[1].localeCompare(b[1]))
-      .map(([value, label]) => ({ value, label }));
-  }, [events]);
-
-  const filteredEvents = React.useMemo(() => {
-    if (events.length === 0) return [];
-
-    return events.filter((event) => {
-      const matchesLocation =
-        location === "all" ||
-        (event.location?.trim().toLowerCase() ?? "") === location.toLowerCase();
-
-      const matchesDate = date.length === 0 || getEventDateKey(event) === date;
-
-      const matchesSearch =
-        normalizedSearch.length === 0 ||
-        [
-          event.title,
-          event.description ?? "",
-          event.organization.name,
-          event.location ?? "",
-          getEventTimezone(event) ?? "",
-        ]
-          .join(" ")
-          .toLowerCase()
-          .includes(normalizedSearch);
-
-      return matchesLocation && matchesDate && matchesSearch;
-    });
-  }, [events, location, date, normalizedSearch]);
-
-  const isFiltering =
-    normalizedSearch.length > 0 || location !== "all" || date.length > 0;
-
-  const handleResetFilters = React.useCallback(() => {
-    setSearch("");
-    setLocation("all");
-    setDate("");
-  }, []);
 
   return (
     <AppShell
@@ -104,213 +28,14 @@ export default function EventsPage() {
       ]}
       headerRight={<UserAvatar />}
     >
-      <TestCalendar />
       <RedirectToSignIn />
-      <section className="space-y-6">
-        <Card className="space-y-3 rounded-3xl border-none bg-gradient-to-r from-primary/10 via-primary/5 to-transparent p-8 text-foreground shadow-sm">
-          <div className="flex flex-col gap-2">
-            <p className="text-muted-foreground text-sm">
-              Upcoming programming
-            </p>
-            <h1 className="font-semibold text-3xl tracking-tight sm:text-4xl">
-              Your events at a glance
-            </h1>
-            <p className="max-w-2xl text-muted-foreground text-sm">
-              Explore approved events from the organizations you follow. Add
-              them to your calendar in a click and stay aligned with your team.
-            </p>
-          </div>
-          <div className="flex flex-wrap items-center gap-3 text-muted-foreground text-sm">
-            <span>
-              Showing {filteredEvents.length} of {events.length} upcoming events
-            </span>
-            {eventsQuery.isLoading ? (
-              <span className="inline-flex items-center gap-2">
-                <Loader2 className="size-4 animate-spin" aria-hidden /> Loading
-                latest schedule
-              </span>
-            ) : null}
-          </div>
-        </Card>
-
-        <FiltersPanel
-          search={search}
-          onSearchChange={setSearch}
-          location={location}
-          onLocationChange={setLocation}
-          locationOptions={locationOptions}
-          date={date}
-          onDateChange={setDate}
-          onReset={handleResetFilters}
-          isFiltering={isFiltering}
-        />
-
-        {eventsQuery.isLoading ? (
-          <EventsSkeleton />
-        ) : eventsQuery.isError ? (
-          <ErrorState onRetry={eventsQuery.refetch} />
-        ) : filteredEvents.length === 0 ? (
-          <EmptyState isFiltering={isFiltering} onReset={handleResetFilters} />
-        ) : (
-          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-            {filteredEvents.map((event) => (
-              <EventCard key={event.id} event={event} />
-            ))}
-          </div>
-        )}
-      </section>
+      <EventsCalendar
+        events={eventsQuery.data ?? []}
+        isLoading={eventsQuery.isLoading}
+        isFetching={eventsQuery.isFetching}
+        isError={eventsQuery.isError}
+        onRetry={eventsQuery.refetch}
+      />
     </AppShell>
-  );
-}
-
-function FiltersPanel({
-  search,
-  onSearchChange,
-  location,
-  onLocationChange,
-  locationOptions,
-  date,
-  onDateChange,
-  onReset,
-  isFiltering,
-}: {
-  search: string;
-  onSearchChange: (value: string) => void;
-  location: string;
-  onLocationChange: (value: string) => void;
-  locationOptions: { value: string; label: string }[];
-  date: string;
-  onDateChange: (value: string) => void;
-  onReset: () => void;
-  isFiltering: boolean;
-}) {
-  return (
-    <Card className="space-y-4 rounded-2xl border border-border/60 bg-card/80 p-5 shadow-sm">
-      <div className="flex items-center gap-2 text-muted-foreground text-sm">
-        <Filter className="size-4" aria-hidden />
-        <span>Refine what you see</span>
-      </div>
-      <div className="grid gap-4 md:grid-cols-3">
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="events-search">Search</Label>
-          <Input
-            id="events-search"
-            value={search}
-            placeholder="Search by title, organization, or keyword"
-            onChange={(event) => onSearchChange(event.target.value)}
-          />
-        </div>
-        <div className="flex flex-col gap-2">
-          <Label>Location</Label>
-          <Select value={location} onValueChange={onLocationChange}>
-            <SelectTrigger className="w-full">
-              <SelectValue placeholder="All locations" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All locations</SelectItem>
-              {locationOptions.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="events-date">Start date</Label>
-          <Input
-            id="events-date"
-            type="date"
-            value={date}
-            onChange={(event) => onDateChange(event.target.value)}
-          />
-        </div>
-      </div>
-      <div className="flex flex-wrap items-center gap-3">
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={onReset}
-          disabled={!isFiltering}
-        >
-          <RefreshCw className="mr-2 size-4" aria-hidden /> Reset filters
-        </Button>
-        {isFiltering ? (
-          <span className="text-muted-foreground text-xs">
-            Adjust filters to broaden your view.
-          </span>
-        ) : null}
-      </div>
-    </Card>
-  );
-}
-
-function EventsSkeleton() {
-  return (
-    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-      {Array.from({ length: 6 }).map((_, index) => (
-        <Card
-          key={index}
-          className="flex h-full flex-col gap-4 rounded-2xl border border-border/40 bg-card/60 p-5"
-        >
-          <Skeleton className="h-32 w-full rounded-xl" />
-          <div className="space-y-3">
-            <Skeleton className="h-4 w-24" />
-            <Skeleton className="h-5 w-3/4" />
-            <Skeleton className="h-4 w-1/2" />
-            <Skeleton className="h-4 w-2/3" />
-          </div>
-          <div className="mt-auto flex gap-2">
-            <Skeleton className="h-8 w-20" />
-            <Skeleton className="h-8 w-20" />
-            <Skeleton className="h-8 w-16" />
-          </div>
-        </Card>
-      ))}
-    </div>
-  );
-}
-
-function ErrorState({ onRetry }: { onRetry: () => void }) {
-  return (
-    <Card className="flex flex-col items-center gap-4 rounded-2xl border border-destructive/50 bg-destructive/10 p-8 text-center text-destructive">
-      <AlertCircle className="size-8" aria-hidden />
-      <div className="space-y-2">
-        <h2 className="font-semibold text-lg">We couldn’t load your events</h2>
-        <p className="text-sm">Check your connection and try again.</p>
-      </div>
-      <Button variant="destructive" onClick={onRetry} type="button">
-        Try again
-      </Button>
-    </Card>
-  );
-}
-
-function EmptyState({
-  isFiltering,
-  onReset,
-}: {
-  isFiltering: boolean;
-  onReset: () => void;
-}) {
-  return (
-    <Card className="flex flex-col items-center gap-4 rounded-2xl border border-dashed border-border/60 bg-card/60 p-8 text-center text-muted-foreground">
-      <div className="space-y-2">
-        <h2 className="font-semibold text-lg text-foreground">
-          {isFiltering ? "No events match your filters" : "No upcoming events"}
-        </h2>
-        <p className="text-sm">
-          {isFiltering
-            ? "Broaden your filters or clear them to see more programming."
-            : "Once organizations publish new events they’ll show up here."}
-        </p>
-      </div>
-      {isFiltering ? (
-        <Button type="button" variant="outline" onClick={onReset}>
-          Clear filters
-        </Button>
-      ) : null}
-    </Card>
   );
 }

--- a/apps/server/src/components/BigCalendarToolbar.tsx
+++ b/apps/server/src/components/BigCalendarToolbar.tsx
@@ -1,105 +1,72 @@
-import { Navigate, ToolbarProps } from "react-big-calendar";
-
-import { Views } from "react-big-calendar";
-import { cn } from "@/lib/utils";
-import { useState } from "react";
+import { Navigate, ToolbarProps, Views } from "react-big-calendar";
 import { format } from "date-fns";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
-export const BigCalendarToolbar = (props: ToolbarProps) => {
-  const [viewState, setViewState] = useState<string>(Views.MONTH);
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
-  const goToDayView = () => {
-    props.onView(Views.DAY);
-    setViewState(Views.DAY);
-  };
-  const goToWeekView = () => {
-    props.onView(Views.WEEK);
-    setViewState(Views.WEEK);
-  };
-  const goToMonthView = () => {
-    props.onView(Views.MONTH);
-    setViewState(Views.MONTH);
-  };
-  const goToAgendaView = () => {
-    props.onView(Views.AGENDA);
-    setViewState(Views.AGENDA);
-  };
-
-  const goToBack = () => {
-    props.onNavigate(Navigate.PREVIOUS);
-  };
-
-  const goToNext = () => {
-    props.onNavigate(Navigate.NEXT);
-  };
-
-  const goToToday = () => {
-    // props.onView(Views.DAY);
-    // setViewState(Views.DAY);
-    props.onNavigate(Navigate.TODAY);
-  };
-
-  // if you decided to inject a datepicker such as MUI or React Widgets ones, use this function on datepicker onChange
-  const goToSpecificDate = (newDate: Date) => {
-    props.onNavigate(Navigate.DATE, newDate);
-  };
-
-  const messages = {
-    today: "Today",
-    month: "Month",
-    week: "Week",
-    day: "Day",
-    agenda: "Agenda",
-    next: "Next",
-    back: "Back",
-  };
+export const BigCalendarToolbar = ({ date, view, views, onNavigate, onView }: ToolbarProps) => {
+  const availableViews = (Array.isArray(views) && views.length > 0
+    ? views
+    : Object.values(Views)) as string[];
+  const currentView = view ?? Views.MONTH;
 
   return (
-    <div className="rbc-toolbar flex !px-0 !justify-between">
-      <div className="flex space-x-1">
-        <button type="button">&#8249;</button>
-        <button
+    <div className="flex flex-col gap-3 border-b border-border/60 pb-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-center gap-2">
+        <Button
           type="button"
-          className={cn({ "rbc-active": viewState === Views.AGENDA })}
-          onClick={goToToday}
+          variant="outline"
+          size="icon"
+          onClick={() => onNavigate?.(Navigate.PREVIOUS)}
+          aria-label="Go to previous period"
+          className="rounded-full shadow-sm"
         >
-          {messages.today}
-        </button>
-        <button type="button" onClick={goToNext}>
-          &#8250;
-        </button>
+          <ChevronLeft className="size-4" aria-hidden />
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={() => onNavigate?.(Navigate.TODAY)}
+          className="rounded-full shadow-sm"
+        >
+          Today
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          onClick={() => onNavigate?.(Navigate.NEXT)}
+          aria-label="Go to next period"
+          className="rounded-full shadow-sm"
+        >
+          <ChevronRight className="size-4" aria-hidden />
+        </Button>
       </div>
-      <label>{format(props.date, "MMMM yyyy")}</label>
 
-      <div className="flex space-x-1">
-        <button
-          type="button"
-          className={cn({ "rbc-active": viewState === Views.MONTH })}
-          onClick={goToMonthView}
-        >
-          {messages.month}
-        </button>
-        <button
-          type="button"
-          className={cn({ "rbc-active": viewState === Views.WEEK })}
-          onClick={goToWeekView}
-        >
-          {messages.week}
-        </button>
-        <button
-          type="button"
-          className={cn({ "rbc-active": viewState === Views.DAY })}
-          onClick={goToDayView}
-        >
-          {messages.day}
-        </button>
-        <button
-          type="button"
-          className={cn({ "rbc-active": viewState === Views.AGENDA })}
-          onClick={goToAgendaView}
-        >
-          {messages.agenda}
-        </button>
+      <div className="text-center font-semibold text-lg tracking-tight text-foreground sm:text-left">
+        {format(date ?? new Date(), "MMMM yyyy")}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        {availableViews.map((availableView) => (
+          <Button
+            key={availableView}
+            type="button"
+            variant={currentView === availableView ? "default" : "ghost"}
+            size="sm"
+            onClick={() => onView?.(availableView)}
+            className={cn(
+              "rounded-full shadow-sm",
+              currentView === availableView
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {availableView.charAt(0).toUpperCase() + availableView.slice(1)}
+          </Button>
+        ))}
       </div>
     </div>
   );

--- a/apps/server/src/components/events/EventsCalendar.tsx
+++ b/apps/server/src/components/events/EventsCalendar.tsx
@@ -1,0 +1,485 @@
+"use client";
+
+import "@/styles/big-calendar.css";
+
+import * as React from "react";
+import Link from "next/link";
+import { addHours, format } from "date-fns";
+import type { EventProps } from "react-big-calendar";
+import { Views } from "react-big-calendar";
+import {
+  AlertCircle,
+  CalendarClock,
+  CalendarPlus,
+  Clock,
+  Filter,
+  LinkIcon,
+  Loader2,
+  MapPin,
+  RefreshCw,
+} from "lucide-react";
+
+import { BigCalendar, localizer } from "@/components/BigCalendar";
+import { BigCalendarToolbar } from "@/components/BigCalendarToolbar";
+import type { UpcomingEvent } from "@/types/events";
+import { formatDateBadge, getEventTimezone } from "@/lib/calendar-links";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+type EventsCalendarProps = {
+  events: UpcomingEvent[];
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  onRetry: () => void;
+};
+
+type CalendarEvent = UpcomingEvent & {
+  start: Date;
+  end: Date;
+};
+
+export function EventsCalendar({
+  events,
+  isLoading,
+  isFetching,
+  isError,
+  onRetry,
+}: EventsCalendarProps) {
+  const [search, setSearch] = React.useState("");
+  const [location, setLocation] = React.useState("all");
+  const [date, setDate] = React.useState("");
+  const [view, setView] = React.useState(Views.MONTH);
+  const [calendarDate, setCalendarDate] = React.useState(new Date());
+  const [selectedEventId, setSelectedEventId] = React.useState<string | null>(null);
+
+  const normalizedSearch = search.trim().toLowerCase();
+
+  const locationOptions = React.useMemo(() => {
+    const unique = new Map<string, string>();
+    for (const event of events) {
+      const label = event.location?.trim();
+      if (!label || label.length === 0) continue;
+      const key = label.toLowerCase();
+      if (!unique.has(key)) {
+        unique.set(key, label);
+      }
+    }
+    return Array.from(unique.entries())
+      .sort((a, b) => a[1].localeCompare(b[1]))
+      .map(([value, label]) => ({ value, label }));
+  }, [events]);
+
+  const filteredEvents = React.useMemo(() => {
+    if (events.length === 0) return [];
+
+    return events.filter((event) => {
+      const matchesLocation =
+        location === "all" ||
+        (event.location?.trim().toLowerCase() ?? "") === location.toLowerCase();
+
+      const matchesDate = date.length === 0 || getEventDateKey(event) === date;
+
+      const matchesSearch =
+        normalizedSearch.length === 0 ||
+        [
+          event.title,
+          event.description ?? "",
+          event.organization.name,
+          event.location ?? "",
+          getEventTimezone(event) ?? "",
+        ]
+          .join(" ")
+          .toLowerCase()
+          .includes(normalizedSearch);
+
+      return matchesLocation && matchesDate && matchesSearch;
+    });
+  }, [events, location, date, normalizedSearch]);
+
+  const calendarEvents = React.useMemo<CalendarEvent[]>(() => {
+    return filteredEvents.map((event) => {
+      const start = new Date(event.startAt);
+      const end = event.endAt ? new Date(event.endAt) : addHours(start, 1);
+
+      return {
+        ...event,
+        start,
+        end,
+      };
+    });
+  }, [filteredEvents]);
+
+  const isFiltering =
+    normalizedSearch.length > 0 || location !== "all" || date.length > 0;
+
+  const selectedEvent = React.useMemo(() => {
+    if (!selectedEventId) return null;
+    return calendarEvents.find((event) => event.id === selectedEventId) ?? null;
+  }, [calendarEvents, selectedEventId]);
+
+  const handleResetFilters = React.useCallback(() => {
+    setSearch("");
+    setLocation("all");
+    setDate("");
+  }, []);
+
+  const handleNavigate = React.useCallback((newDate: Date) => {
+    setCalendarDate(newDate);
+  }, []);
+
+  const handleViewChange = React.useCallback((newView: string) => {
+    setView(newView);
+  }, []);
+
+  const handleSelectEvent = React.useCallback((event: CalendarEvent) => {
+    setSelectedEventId(event.id);
+  }, []);
+
+  const handleModalOpenChange = React.useCallback((open: boolean) => {
+    if (!open) {
+      setSelectedEventId(null);
+    }
+  }, []);
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <section className="space-y-6">
+        <Card className="space-y-3 rounded-3xl border-none bg-gradient-to-r from-primary/10 via-primary/5 to-transparent p-8 text-foreground shadow-sm">
+          <div className="flex flex-col gap-2">
+            <p className="text-muted-foreground text-sm">
+              Upcoming programming
+            </p>
+            <h1 className="font-semibold text-3xl tracking-tight sm:text-4xl">
+              Your events at a glance
+            </h1>
+            <p className="max-w-2xl text-muted-foreground text-sm">
+              Explore approved events from the organizations you follow. Add
+              them to your calendar in a click and stay aligned with your team.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3 text-muted-foreground text-sm">
+            <span>
+              Showing {filteredEvents.length} of {events.length} upcoming events
+            </span>
+            {isFetching ? (
+              <span className="inline-flex items-center gap-2">
+                <Loader2 className="size-4 animate-spin" aria-hidden /> Syncing latest schedule
+              </span>
+            ) : null}
+          </div>
+        </Card>
+
+        <FiltersPanel
+          search={search}
+          onSearchChange={setSearch}
+          location={location}
+          onLocationChange={setLocation}
+          locationOptions={locationOptions}
+          date={date}
+          onDateChange={setDate}
+          onReset={handleResetFilters}
+          isFiltering={isFiltering}
+        />
+
+        {isLoading ? (
+          <EventsCalendarSkeleton />
+        ) : isError ? (
+          <CalendarErrorState onRetry={onRetry} />
+        ) : calendarEvents.length === 0 ? (
+          <CalendarEmptyState isFiltering={isFiltering} onReset={handleResetFilters} />
+        ) : (
+          <Card className="rounded-3xl border border-border/60 bg-card/90 p-4 shadow-lg">
+            <div className="rounded-2xl bg-background/60 p-3 shadow-inner">
+              <BigCalendar
+                localizer={localizer}
+                views={[Views.MONTH, Views.WEEK, Views.DAY, Views.AGENDA]}
+                date={calendarDate}
+                onNavigate={handleNavigate}
+                view={view}
+                onView={handleViewChange}
+                events={calendarEvents}
+                startAccessor="start"
+                endAccessor="end"
+                style={{ height: 640 }}
+                components={{
+                  toolbar: BigCalendarToolbar,
+                  event: CalendarEventContent,
+                }}
+                popup
+                onSelectEvent={handleSelectEvent}
+                dayPropGetter={() => ({
+                  className:
+                    "[&.rbc-today]:bg-primary/10 [&.rbc-today]:border [&.rbc-today]:border-primary/30",
+                })}
+                eventPropGetter={() => ({
+                  className:
+                    "!border-none !bg-transparent px-0 py-0 transition-[transform] hover:z-10 hover:scale-[1.01]",
+                })}
+              />
+            </div>
+          </Card>
+        )}
+
+        <Dialog open={Boolean(selectedEvent)} onOpenChange={handleModalOpenChange}>
+          <DialogContent className="max-w-2xl rounded-3xl">
+            {selectedEvent ? (
+              <>
+                <DialogHeader>
+                  <DialogTitle className="text-balance text-2xl font-semibold">
+                    {selectedEvent.title}
+                  </DialogTitle>
+                </DialogHeader>
+                <ScrollArea className="max-h-[50vh] pr-4">
+                  <div className="space-y-4 py-2">
+                    <div className="flex flex-wrap items-center gap-3 text-muted-foreground text-sm">
+                      <Badge variant="secondary" className="rounded-full px-3 py-1">
+                        {selectedEvent.organization.name}
+                      </Badge>
+                      <div className="inline-flex items-center gap-2">
+                        <CalendarClock className="size-4" aria-hidden />
+                        <span>
+                          {format(selectedEvent.start, "EEEE, MMMM d yyyy")}
+                        </span>
+                      </div>
+                      <div className="inline-flex items-center gap-2">
+                        <Clock className="size-4" aria-hidden />
+                        <span>
+                          {format(selectedEvent.start, "p")} – {format(selectedEvent.end, "p")} {getEventTimezone(selectedEvent)}
+                        </span>
+                      </div>
+                    </div>
+                    {selectedEvent.location ? (
+                      <div className="inline-flex items-center gap-2 text-muted-foreground text-sm">
+                        <MapPin className="size-4" aria-hidden />
+                        <span>{selectedEvent.location}</span>
+                      </div>
+                    ) : null}
+                    <p className="text-sm leading-relaxed text-foreground/80">
+                      {selectedEvent.description ?? "No description provided for this event."}
+                    </p>
+                  </div>
+                </ScrollArea>
+                <DialogFooter className="gap-2">
+                  {selectedEvent.url ? (
+                    <Button asChild variant="outline">
+                      <Link href={selectedEvent.url} target="_blank" rel="noopener noreferrer">
+                        <LinkIcon className="mr-2 size-4" aria-hidden /> View event page
+                      </Link>
+                    </Button>
+                  ) : null}
+                  <Button type="button">
+                    <CalendarPlus className="mr-2 size-4" aria-hidden />
+                    Add to my calendar
+                  </Button>
+                </DialogFooter>
+              </>
+            ) : null}
+          </DialogContent>
+        </Dialog>
+      </section>
+    </TooltipProvider>
+  );
+}
+
+function CalendarEventContent({ event }: EventProps<CalendarEvent>) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          className={cn(
+            "flex h-full w-full flex-col justify-center gap-1 rounded-xl border border-primary/20 bg-primary/10 px-3 py-2 text-left text-xs shadow-sm transition-colors",
+            "hover:border-primary/40 hover:bg-primary/15 dark:border-primary/30 dark:bg-primary/15",
+          )}
+        >
+          <span className="line-clamp-2 font-medium text-sm text-primary">
+            {event.title}
+          </span>
+          <div className="flex flex-wrap items-center gap-1 text-muted-foreground">
+            <Badge
+              variant="outline"
+              className="rounded-full border-primary/20 bg-background/80 px-2 py-0 text-[10px] font-medium text-primary"
+            >
+              {event.organization.name}
+            </Badge>
+            <span>{format(event.start, "p")}</span>
+          </div>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs rounded-xl border-border/60 bg-card p-3 text-left">
+        <p className="font-medium text-sm text-foreground">{event.title}</p>
+        <p className="text-muted-foreground text-xs">
+          {format(event.start, "EEEE, MMM d • p")} – {format(event.end, "p")}
+        </p>
+        {event.location ? (
+          <p className="mt-1 text-muted-foreground text-xs">{event.location}</p>
+        ) : null}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function FiltersPanel({
+  search,
+  onSearchChange,
+  location,
+  onLocationChange,
+  locationOptions,
+  date,
+  onDateChange,
+  onReset,
+  isFiltering,
+}: {
+  search: string;
+  onSearchChange: (value: string) => void;
+  location: string;
+  onLocationChange: (value: string) => void;
+  locationOptions: { value: string; label: string }[];
+  date: string;
+  onDateChange: (value: string) => void;
+  onReset: () => void;
+  isFiltering: boolean;
+}) {
+  return (
+    <Card className="space-y-4 rounded-2xl border border-border/60 bg-card/80 p-5 shadow-sm">
+      <div className="flex items-center gap-2 text-muted-foreground text-sm">
+        <Filter className="size-4" aria-hidden />
+        <span>Refine what you see</span>
+      </div>
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="events-search">Search</Label>
+          <Input
+            id="events-search"
+            value={search}
+            placeholder="Search by title, organization, or keyword"
+            onChange={(event) => onSearchChange(event.target.value)}
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <Label>Location</Label>
+          <Select value={location} onValueChange={onLocationChange}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="All locations" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All locations</SelectItem>
+              {locationOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="events-date">Start date</Label>
+          <Input
+            id="events-date"
+            type="date"
+            value={date}
+            onChange={(event) => onDateChange(event.target.value)}
+          />
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onReset}
+          disabled={!isFiltering}
+        >
+          <RefreshCw className="mr-2 size-4" aria-hidden /> Reset filters
+        </Button>
+        {isFiltering ? (
+          <span className="text-muted-foreground text-xs">
+            Adjust filters to broaden your view.
+          </span>
+        ) : null}
+      </div>
+    </Card>
+  );
+}
+
+function EventsCalendarSkeleton() {
+  return (
+    <Card className="rounded-3xl border border-border/60 bg-card/80 p-4 shadow-sm">
+      <Skeleton className="h-8 w-48" />
+      <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <Skeleton key={index} className="h-32 rounded-2xl" />
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+function CalendarErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <Card className="flex flex-col items-center gap-4 rounded-2xl border border-destructive/40 bg-destructive/10 p-8 text-center text-destructive">
+      <AlertCircle className="size-8" aria-hidden />
+      <div className="space-y-2">
+        <h2 className="font-semibold text-lg">We couldn’t load your events</h2>
+        <p className="text-sm">Check your connection and try again.</p>
+      </div>
+      <Button variant="destructive" onClick={onRetry} type="button">
+        Try again
+      </Button>
+    </Card>
+  );
+}
+
+function CalendarEmptyState({
+  isFiltering,
+  onReset,
+}: {
+  isFiltering: boolean;
+  onReset: () => void;
+}) {
+  return (
+    <Card className="flex flex-col items-center gap-4 rounded-2xl border border-dashed border-border/60 bg-card/60 p-8 text-center text-muted-foreground">
+      <div className="space-y-2">
+        <h2 className="font-semibold text-lg text-foreground">
+          {isFiltering ? "No events match your filters" : "No upcoming events"}
+        </h2>
+        <p className="text-sm">
+          {isFiltering
+            ? "Broaden your filters or clear them to see more programming."
+            : "Once organizations publish new events they’ll show up here."}
+        </p>
+      </div>
+      {isFiltering ? (
+        <Button type="button" variant="outline" onClick={onReset}>
+          Clear filters
+        </Button>
+      ) : null}
+    </Card>
+  );
+}
+
+function getEventDateKey(event: UpcomingEvent): string {
+  return formatDateBadge(event);
+}
+
+export default EventsCalendar;

--- a/apps/server/src/styles/big-calendar.css
+++ b/apps/server/src/styles/big-calendar.css
@@ -1,48 +1,68 @@
 @import url("react-big-calendar/lib/css/react-big-calendar.css");
 @import "react-big-calendar/lib/addons/dragAndDrop/styles.css";
-/* @import url("react-big-calendar/lib/css/react-big-calendar.css"); */
 
 .rbc-toolbar {
-  padding-left: 0 !important;
-  padding-right: 0 !important;
+  padding: 0 !important;
+  margin-bottom: 1.25rem;
 }
+
+.rbc-toolbar button {
+  color: inherit;
+}
+
 .rbc-header {
-  background: hsl(var(--primary));
-  color: hsl(var(--accent));
-  padding: 4px;
-  font-weight: bold;
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  padding: 0.75rem 0.5rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
-.rbc-toolbar {
-  padding: 0 0.75rem;
+.rbc-month-view {
+  border: none;
+}
+
+.rbc-time-view {
+  border: none;
+}
+
+.rbc-time-header {
+  border: none;
+}
+
+.rbc-time-content {
+  border: none;
+}
+
+.rbc-day-bg + .rbc-day-bg,
+.rbc-time-header-content + .rbc-time-header-content,
+.rbc-timeslot-group {
+  border-color: hsl(var(--border));
 }
 
 .rbc-off-range-bg {
-  background: hsl(var(--calendar-off-range));
-  /* background: #f3f4f5; */
+  background: hsl(var(--muted) / 0.4);
+}
+
+.rbc-today {
+  background-color: hsl(var(--primary) / 0.08);
 }
 
 .rbc-event {
   padding: 0 !important;
   font-size: 14px;
-  margin: 0 0px 1px 0px;
+  margin: 0 0 6px;
 }
-
-.rbc-today {
-  background-color: hsl(var(--calendar-today));
-}
-
-.rbc-event-label {
-  padding: 1px 4px !important;
-}
-
-/* .rbc-event-content{
-} */
 
 .rbc-event,
 .rbc-event.rbc-selected {
-  background-color: transparent;
+  background: transparent;
   color: inherit;
+}
+
+.rbc-event-label {
+  display: none;
 }
 
 .rbc-time-view .rbc-row {
@@ -51,25 +71,26 @@
 }
 
 .rbc-row-segment {
-  padding: 0px 4px 0px 4px;
+  padding: 0 4px;
 }
 
-.rbc-toolbar button {
-  color: hsl(var(--secondary-foreground));
+.rbc-agenda-view table.rbc-agenda-table {
+  border: none;
 }
 
-.rbc-toolbar button.rbc-active,
-.rbc-toolbar button.rbc-active:hover,
-.rbc-toolbar button:hover {
-  /* border-color: hsl(var(--border)) !important; */
-  background-color: hsl(var(--primary));
-  color: hsl(var(--primary-foreground));
+.rbc-agenda-view table.rbc-agenda-table thead > tr > th {
+  padding: 0.75rem;
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  font-weight: 600;
 }
 
-/* .rbc-toolbar button:hover { */
-/*   background-color: hsl(var(--primary) / 0.9); */
-/* } */
-.rbc-toolbar button.rbc-active {
-  background-color: hsl(var(--primary)) !important;
-  color: hsl(var(--primary-foreground)) !important;
+.rbc-agenda-view table.rbc-agenda-table tbody > tr + tr {
+  border-top: 1px solid hsl(var(--border));
+}
+
+.rbc-agenda-date-cell,
+.rbc-agenda-time-cell,
+.rbc-agenda-event-cell {
+  padding: 0.75rem;
 }


### PR DESCRIPTION
## Summary
- replace the events page grid with a reusable EventsCalendar component that maps upcoming events into react-big-calendar, adds filtering controls, and shows modal details with an add-to-calendar action.
- update the events page to request a larger set of approved events and render the new calendar-focused experience.
- refresh the calendar toolbar and base styles so the calendar matches the dashboard look and feel.

## Testing
- bun run --filter server build *(fails: Next.js could not download remote font assets in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dbde630b048327a7abd722b2dc8bf0