### PR TITLE
Add trusted provider trust controls and auto-approval surfacing

### DIFF
--- a/apps/server/src/app/(site)/admin/providers/[providerId]/page.tsx
+++ b/apps/server/src/app/(site)/admin/providers/[providerId]/page.tsx
@@ -19,12 +19,13 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import {
-	Form,
-	FormControl,
-	FormField,
-	FormItem,
-	FormLabel,
-	FormMessage,
+        Form,
+        FormControl,
+        FormDescription,
+        FormField,
+        FormItem,
+        FormLabel,
+        FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import {
@@ -50,13 +51,14 @@ const providerCategories = [
 ] as const;
 
 type ProviderFormValues = {
-	id?: string;
-	category: string;
-	name: string;
-	description: string;
-	status: (typeof providerStatuses)[number];
-	displayName: string;
-	email: string;
+        id?: string;
+        category: string;
+        name: string;
+        description: string;
+        status: (typeof providerStatuses)[number];
+        trusted: boolean;
+        displayName: string;
+        email: string;
 	imapHost: string;
 	imapPort: string;
 	imapSecure: boolean;
@@ -71,11 +73,12 @@ type ProviderFormValues = {
 };
 
 const emptyFormValues: ProviderFormValues = {
-	category: "",
-	name: "",
-	description: "",
-	status: "draft",
-	displayName: "",
+        category: "",
+        name: "",
+        description: "",
+        status: "draft",
+        trusted: false,
+        displayName: "",
 	email: "",
 	imapHost: "",
 	imapPort: "993",
@@ -153,13 +156,14 @@ export default function ProviderDetailPage() {
 		const smtp = (config.smtp ?? {}) as Record<string, unknown>;
 		const smtpAuth = (smtp.auth ?? {}) as Record<string, unknown>;
 
-		form.reset({
-			id: detail.id,
-			category: detail.category,
-			name: detail.name,
-			description: detail.description ?? "",
-			status: (detail.status as ProviderFormValues["status"]) ?? "draft",
-			displayName: asString(config.displayName, ""),
+                form.reset({
+                        id: detail.id,
+                        category: detail.category,
+                        name: detail.name,
+                        description: detail.description ?? "",
+                        status: (detail.status as ProviderFormValues["status"]) ?? "draft",
+                        trusted: detail.trusted ?? false,
+                        displayName: asString(config.displayName, ""),
 			email: asString(config.email, ""),
 			imapHost: asString(imap.host, ""),
 			imapPort: asPortString(imap.port, "993"),
@@ -242,15 +246,16 @@ export default function ProviderDetailPage() {
 	}, [configFromValues, form, isNew, providerId, smtpTestMutation]);
 
 	const onSubmit = form.handleSubmit((values) => {
-		const payload = {
-			id: isNew ? undefined : providerId,
-			category: values.category,
-			name: values.name,
-			description:
-				values.description.trim().length > 0 ? values.description : null,
-			status: values.status,
-			config: configFromValues(values),
-		} as const;
+                const payload = {
+                        id: isNew ? undefined : providerId,
+                        category: values.category,
+                        name: values.name,
+                        description:
+                                values.description.trim().length > 0 ? values.description : null,
+                        status: values.status,
+                        trusted: values.trusted,
+                        config: configFromValues(values),
+                } as const;
 
 		upsertMutation.mutate(payload);
 	});
@@ -352,43 +357,72 @@ export default function ProviderDetailPage() {
 											</FormItem>
 										)}
 									/>
-									<FormField
-										control={form.control}
-										name="status"
-										rules={{ required: "Status is required" }}
-										render={({ field }) => (
-											<FormItem>
-												<FormLabel>Status</FormLabel>
-												<Select
-													value={field.value}
-													onValueChange={field.onChange}
-												>
-													<FormControl>
-														<SelectTrigger className="w-full">
-															<SelectValue placeholder="Select status" />
-														</SelectTrigger>
-													</FormControl>
-													<SelectContent>
-														{providerStatuses.map((status) => (
-															<SelectItem
-																key={status}
-																value={status}
-																className="capitalize"
-															>
-																{status}
-															</SelectItem>
-														))}
-													</SelectContent>
-												</Select>
-												<FormMessage />
-											</FormItem>
-										)}
-									/>
-									<FormField
-										control={form.control}
-										name="description"
-										render={({ field }) => (
-											<FormItem className="md:col-span-2">
+                                                                        <FormField
+                                                                                control={form.control}
+                                                                                name="status"
+                                                                                rules={{ required: "Status is required" }}
+                                                                                render={({ field }) => (
+                                                                                        <FormItem>
+                                                                                                <FormLabel>Status</FormLabel>
+                                                                                                <Select
+                                                                                                        value={field.value}
+                                                                                                        onValueChange={field.onChange}
+                                                                                                >
+                                                                                                        <FormControl>
+                                                                                                                <SelectTrigger className="w-full">
+                                                                                                                        <SelectValue placeholder="Select status" />
+                                                                                                                </SelectTrigger>
+                                                                                                        </FormControl>
+                                                                                                        <SelectContent>
+                                                                                                                {providerStatuses.map((status) => (
+                                                                                                                        <SelectItem
+                                                                                                                                key={status}
+                                                                                                                                value={status}
+                                                                                                                                className="capitalize"
+                                                                                                                        >
+                                                                                                                                {status}
+                                                                                                                        </SelectItem>
+                                                                                                                ))}
+                                                                                                        </SelectContent>
+                                                                                                </Select>
+                                                                                                <FormMessage />
+                                                                                        </FormItem>
+                                                                                )}
+                                                                        />
+                                                                        <FormField
+                                                                                control={form.control}
+                                                                                name="trusted"
+                                                                                render={({ field }) => (
+                                                                                        <FormItem className="md:col-span-2">
+                                                                                                <div className="flex flex-col gap-3 rounded-lg border border-dashed p-4">
+                                                                                                        <div className="flex flex-col gap-1">
+                                                                                                                <FormLabel className="text-base">
+                                                                                                                        Trusted provider
+                                                                                                                </FormLabel>
+                                                                                                                <FormDescription>
+                                                                                                                        When enabled, events ingested from this provider will be auto-approved without manual review.
+                                                                                                                </FormDescription>
+                                                                                                        </div>
+                                                                                                        <FormControl>
+                                                                                                                <div className="flex items-center justify-between gap-3">
+                                                                                                                        <span className="text-muted-foreground text-sm">
+                                                                                                                                Toggle to mark this provider as trusted.
+                                                                                                                        </span>
+                                                                                                                        <Switch
+                                                                                                                                checked={field.value}
+                                                                                                                                onCheckedChange={field.onChange}
+                                                                                                                        />
+                                                                                                                </div>
+                                                                                                        </FormControl>
+                                                                                                </div>
+                                                                                        </FormItem>
+                                                                                )}
+                                                                        />
+                                                                        <FormField
+                                                                                control={form.control}
+                                                                                name="description"
+                                                                                render={({ field }) => (
+                                                                                        <FormItem className="md:col-span-2">
 												<FormLabel>Description</FormLabel>
 												<FormControl>
 													<textarea

--- a/apps/server/src/app/(site)/admin/providers/page.tsx
+++ b/apps/server/src/app/(site)/admin/providers/page.tsx
@@ -168,7 +168,16 @@ export default function ProvidersAdminPage() {
 											<TableCell className="text-muted-foreground text-sm">
 												{row.category}
 											</TableCell>
-											<TableCell>{renderStatusBadge(row.status)}</TableCell>
+                                                                                        <TableCell>
+                                                                                                <div className="flex flex-col gap-1">
+                                                                                                        {renderStatusBadge(row.status)}
+                                                                                                        {row.trusted ? (
+                                                                                                                <Badge variant="secondary">
+                                                                                                                        Trusted
+                                                                                                                </Badge>
+                                                                                                        ) : null}
+                                                                                                </div>
+                                                                                        </TableCell>
 											<TableCell className="text-muted-foreground text-sm">
 												{renderLastTestedAt(row.lastTestedAt)}
 											</TableCell>

--- a/apps/server/src/components/admin/events/EventDetailSheet.tsx
+++ b/apps/server/src/components/admin/events/EventDetailSheet.tsx
@@ -4,6 +4,7 @@ import type { EventStatus } from "@/app/(site)/admin/events/event-filters";
 import { statusOptionMap } from "@/app/(site)/admin/events/event-filters";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ShieldCheck } from "lucide-react";
 import {
         Sheet,
         SheetContent,
@@ -32,6 +33,11 @@ export function EventDetailSheet({
   onClose,
   statusLoading,
 }: EventDetailSheetProps) {
+  const autoApproval = event?.autoApproval ?? null;
+  const autoApprovalReason = autoApproval?.reason.replace(/_/g, " ") ?? "Unknown";
+  const autoApprovalTimestamp = autoApproval?.at
+    ? new Date(autoApproval.at)
+    : null;
   return (
     <Sheet
       open={event != null}
@@ -70,7 +76,31 @@ export function EventDetailSheet({
                 {event.isAllDay ? (
                   <Badge variant="outline">All-day</Badge>
                 ) : null}
+                {autoApproval ? (
+                  <Badge variant="secondary" className="gap-1">
+                    <ShieldCheck className="size-3" />
+                    Auto-approved
+                    {autoApproval.trustedProvider ? " (trusted provider)" : ""}
+                  </Badge>
+                ) : null}
               </div>
+              {autoApproval ? (
+                <div className="rounded-md border border-dashed bg-muted/40 p-3 text-muted-foreground text-sm">
+                  <p className="flex items-center gap-2 font-medium text-foreground">
+                    <ShieldCheck className="size-4" />
+                    Auto-approval details
+                  </p>
+                  <p>
+                    Reason: {autoApprovalReason}
+                    {autoApproval.providerId
+                      ? ` • Provider ID: ${autoApproval.providerId}`
+                      : ""}
+                  </p>
+                  {autoApprovalTimestamp ? (
+                    <p>Recorded at: {autoApprovalTimestamp.toLocaleString()}</p>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
             <div className="space-y-1 text-sm">
               <p className="font-semibold text-foreground">Schedule</p>

--- a/apps/server/src/components/admin/events/EventListView.tsx
+++ b/apps/server/src/components/admin/events/EventListView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CalendarDays, ExternalLink, Tag } from "lucide-react";
+import { CalendarDays, ExternalLink, ShieldCheck, Tag } from "lucide-react";
 import { statusOptionMap } from "@/app/(site)/admin/events/event-filters";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -187,11 +187,22 @@ export function EventListView({
 										) : null}
 									</div>
 								</TableCell>
-								<TableCell>
-									<Badge variant={statusOptionMap[event.status].badgeVariant}>
-										{statusOptionMap[event.status].label}
-									</Badge>
-								</TableCell>
+                                                                <TableCell>
+                                                                        <div className="flex flex-col gap-1">
+                                                                                <Badge variant={statusOptionMap[event.status].badgeVariant}>
+                                                                                        {statusOptionMap[event.status].label}
+                                                                                </Badge>
+                                                                                {event.autoApproval ? (
+                                                                                        <span className="flex items-center gap-1 text-muted-foreground text-xs">
+                                                                                                <ShieldCheck className="size-3" />
+                                                                                                Auto-approved
+                                                                                                {event.autoApproval.trustedProvider
+                                                                                                        ? " (trusted provider)"
+                                                                                                        : ""}
+                                                                                        </span>
+                                                                                ) : null}
+                                                                        </div>
+                                                                </TableCell>
 								<TableCell>
 									<Badge variant="outline">{event.priority}</Badge>
 								</TableCell>

--- a/apps/server/src/components/admin/events/EventPreview.tsx
+++ b/apps/server/src/components/admin/events/EventPreview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CalendarClock, Clock, MapPin, Tag } from "lucide-react";
+import { CalendarClock, Clock, MapPin, ShieldCheck, Tag } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { Badge } from "@/components/ui/badge";
@@ -48,11 +48,12 @@ export function EventPreview({
 		layout === "card"
 			? (event.location ?? "No location")
 			: (event.location ?? "");
-	const shouldRenderBadges =
-		Boolean(badgePrefix) ||
-		inlineTitle ||
-		event.isAllDay ||
-		Boolean(event.flag);
+        const shouldRenderBadges =
+                Boolean(badgePrefix) ||
+                inlineTitle ||
+                event.isAllDay ||
+                Boolean(event.flag) ||
+                Boolean(event.autoApproval);
 
 	return (
 		<div className={cn(containerClasses, className)}>
@@ -60,17 +61,28 @@ export function EventPreview({
 			{shouldRenderBadges ? (
 				<div className={badgeRowClasses}>
 					{badgePrefix}
-					{inlineTitle ? titleContent : null}
-					{event.isAllDay ? (
-						<Badge variant="outline" className="uppercase">
-							All-day
-						</Badge>
-					) : null}
-					{event.flag ? (
-						<Badge variant="secondary" className="gap-1">
-							<Tag className={badgeIconClasses} />
-							<span className="min-w-0 break-words">{event.flag.label}</span>
-						</Badge>
+                                        {inlineTitle ? titleContent : null}
+                                        {event.isAllDay ? (
+                                                <Badge variant="outline" className="uppercase">
+                                                        All-day
+                                                </Badge>
+                                        ) : null}
+                                        {event.autoApproval ? (
+                                                <Badge variant="secondary" className="gap-1">
+                                                        <ShieldCheck className={badgeIconClasses} />
+                                                        <span className="min-w-0 break-words">
+                                                                Auto-approved
+                                                                {event.autoApproval.trustedProvider
+                                                                        ? " (trusted provider)"
+                                                                        : ""}
+                                                        </span>
+                                                </Badge>
+                                        ) : null}
+                                        {event.flag ? (
+                                                <Badge variant="secondary" className="gap-1">
+                                                        <Tag className={badgeIconClasses} />
+                                                        <span className="min-w-0 break-words">{event.flag.label}</span>
+                                                </Badge>
 					) : null}
 				</div>
 			) : null}

--- a/apps/server/src/db/migrations/0008_trusted_providers.sql
+++ b/apps/server/src/db/migrations/0008_trusted_providers.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "provider" ADD COLUMN "trusted" boolean DEFAULT false NOT NULL;

--- a/apps/server/src/db/migrations/meta/0008_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1151 @@
+{
+        "id": "4c2d4d1e-9c53-4dc5-a3f0-4ce2bb7d84c6",
+        "prevId": "ecd76f55-9317-47b7-8cc7-302e18c90adf",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.event": {
+			"name": "event",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"flag_id": {
+					"name": "flag_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"location": {
+					"name": "location",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"start_at": {
+					"name": "start_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"end_at": {
+					"name": "end_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_all_day": {
+					"name": "is_all_day",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"is_published": {
+					"name": "is_published",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"external_id": {
+					"name": "external_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"status": {
+					"name": "status",
+					"type": "event_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"priority": {
+					"name": "priority",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 3
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"event_provider_id_external_id_unique": {
+					"name": "event_provider_id_external_id_unique",
+					"columns": [
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "external_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"status_start_at_idx": {
+					"name": "status_start_at_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"start_at\" desc",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"status_created_at_idx": {
+					"name": "status_created_at_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"created_at\" desc",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_start_at_idx": {
+					"name": "provider_start_at_idx",
+					"columns": [
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"start_at\" desc",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_created_at_idx": {
+					"name": "provider_created_at_idx",
+					"columns": [
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"created_at\" desc",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_status_start_at_idx": {
+					"name": "provider_status_start_at_idx",
+					"columns": [
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"start_at\" desc",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_status_created_at_idx": {
+					"name": "provider_status_created_at_idx",
+					"columns": [
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"created_at\" desc",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"event_provider_id_provider_id_fk": {
+					"name": "event_provider_id_provider_id_fk",
+					"tableFrom": "event",
+					"tableTo": "provider",
+					"columnsFrom": ["provider_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"event_flag_id_flag_id_fk": {
+					"name": "event_flag_id_flag_id_fk",
+					"tableFrom": "event",
+					"tableTo": "flag",
+					"columnsFrom": ["flag_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.flag": {
+			"name": "flag",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"priority": {
+					"name": "priority",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"flag_slug_unique": {
+					"name": "flag_slug_unique",
+					"columns": [
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"flag_priority_range": {
+					"name": "flag_priority_range",
+					"value": "\"flag\".\"priority\" >= 1 AND \"flag\".\"priority\" <= 5"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.organization_provider": {
+			"name": "organization_provider",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"organization_provider_organization_id_provider_id_unique": {
+					"name": "organization_provider_organization_id_provider_id_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"organization_provider_organization_id_organization_id_fk": {
+					"name": "organization_provider_organization_id_organization_id_fk",
+					"tableFrom": "organization_provider",
+					"tableTo": "organization",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"organization_provider_provider_id_provider_id_fk": {
+					"name": "organization_provider_provider_id_provider_id_fk",
+					"tableFrom": "organization_provider",
+					"tableTo": "provider",
+					"columnsFrom": ["provider_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider": {
+			"name": "provider",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"config": {
+					"name": "config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+                                "status": {
+                                        "name": "status",
+                                        "type": "provider_status",
+                                        "typeSchema": "public",
+                                        "primaryKey": false,
+                                        "notNull": true,
+                                        "default": "'draft'"
+                                },
+                                "trusted": {
+                                        "name": "trusted",
+                                        "type": "boolean",
+                                        "primaryKey": false,
+                                        "notNull": true,
+                                        "default": false
+                                },
+                                "last_tested_at": {
+                                        "name": "last_tested_at",
+                                        "type": "timestamp with time zone",
+                                        "primaryKey": false,
+                                        "notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.worker_log": {
+			"name": "worker_log",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "bigserial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"ts": {
+					"name": "ts",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"level": {
+					"name": "level",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"msg": {
+					"name": "msg",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.invitation": {
+			"name": "invitation",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"inviter_id": {
+					"name": "inviter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"invitation_inviter_id_user_id_fk": {
+					"name": "invitation_inviter_id_user_id_fk",
+					"tableFrom": "invitation",
+					"tableTo": "user",
+					"columnsFrom": ["inviter_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"invitation_organization_id_organization_id_fk": {
+					"name": "invitation_organization_id_organization_id_fk",
+					"tableFrom": "invitation",
+					"tableTo": "organization",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.member": {
+			"name": "member",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"member_user_id_user_id_fk": {
+					"name": "member_user_id_user_id_fk",
+					"tableFrom": "member",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"member_organization_id_organization_id_fk": {
+					"name": "member_organization_id_organization_id_fk",
+					"tableFrom": "member",
+					"tableTo": "organization",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.organization": {
+			"name": "organization",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"logo": {
+					"name": "logo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"organization_slug_unique": {
+					"name": "organization_slug_unique",
+					"nullsNotDistinct": false,
+					"columns": ["slug"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"impersonated_by": {
+					"name": "impersonated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"active_organization_id": {
+					"name": "active_organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"session_impersonated_by_user_id_fk": {
+					"name": "session_impersonated_by_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["impersonated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"session_active_organization_id_organization_id_fk": {
+					"name": "session_active_organization_id_organization_id_fk",
+					"tableFrom": "session",
+					"tableTo": "organization",
+					"columnsFrom": ["active_organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"banned": {
+					"name": "banned",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"ban_reason": {
+					"name": "ban_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ban_expires": {
+					"name": "ban_expires",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.event_status": {
+			"name": "event_status",
+			"schema": "public",
+			"values": ["pending", "approved", "rejected"]
+		},
+		"public.provider_status": {
+			"name": "provider_status",
+			"schema": "public",
+			"values": ["draft", "beta", "active", "deprecated"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -51,12 +51,19 @@
 			"tag": "0006_fast_unus",
 			"breakpoints": true
 		},
-		{
-			"idx": 7,
-			"version": "7",
-			"when": 1758712155992,
-			"tag": "0007_married_vertigo",
-			"breakpoints": true
-		}
-	]
+                {
+                        "idx": 7,
+                        "version": "7",
+                        "when": 1758712155992,
+                        "tag": "0007_married_vertigo",
+                        "breakpoints": true
+                },
+                {
+                        "idx": 8,
+                        "version": "7",
+                        "when": 1758800000000,
+                        "tag": "0008_trusted_providers",
+                        "breakpoints": true
+                }
+        ]
 }

--- a/apps/server/src/db/schema/app.ts
+++ b/apps/server/src/db/schema/app.ts
@@ -29,19 +29,20 @@ export const eventStatus = pgEnum("event_status", [
 ]);
 
 export const provider = pgTable("provider", {
-	id: text("id").primaryKey(),
-	category: text("category").notNull(),
-	name: text("name").notNull(),
-	description: text("description"),
-	config: jsonb("config")
-		.$type<Record<string, unknown>>()
-		.notNull()
-		.default(sql`'{}'::jsonb`),
-	status: providerStatus("status").notNull().default("draft"),
-	lastTestedAt: timestamp("last_tested_at", { withTimezone: true }),
-	createdAt: timestamp("created_at", { withTimezone: true })
-		.notNull()
-		.defaultNow(),
+        id: text("id").primaryKey(),
+        category: text("category").notNull(),
+        name: text("name").notNull(),
+        description: text("description"),
+        config: jsonb("config")
+                .$type<Record<string, unknown>>()
+                .notNull()
+                .default(sql`'{}'::jsonb`),
+        status: providerStatus("status").notNull().default("draft"),
+        trusted: boolean("trusted").notNull().default(false),
+        lastTestedAt: timestamp("last_tested_at", { withTimezone: true }),
+        createdAt: timestamp("created_at", { withTimezone: true })
+                .notNull()
+                .defaultNow(),
 	updatedAt: timestamp("updated_at", { withTimezone: true })
 		.notNull()
 		.defaultNow(),

--- a/apps/server/src/routers/events.ts
+++ b/apps/server/src/routers/events.ts
@@ -56,9 +56,9 @@ const filterSchema = z.object({
 type EventFilterInput = z.infer<typeof filterSchema>;
 
 type EventSelection = {
-	id: string;
-	providerId: string;
-	flagId: string | null;
+        id: string;
+        providerId: string;
+        flagId: string | null;
 	title: string;
 	description: string | null;
 	location: string | null;
@@ -68,7 +68,7 @@ type EventSelection = {
 	isAllDay: boolean;
 	isPublished: boolean;
 	externalId: string | null;
-	metadata: Record<string, unknown>;
+        metadata: Record<string, unknown> | null;
 	status: (typeof event.status.enumValues)[number];
 	priority: number;
 	createdAt: Date;
@@ -79,6 +79,35 @@ type EventSelection = {
 	flagLabel: string | null;
 	flagPriority: number | null;
 };
+
+type AutoApprovalInfo = {
+        reason: string;
+        providerId: string | null;
+        at: string | null;
+        trustedProvider: boolean;
+};
+
+function parseAutoApproval(
+        metadata: Record<string, unknown> | null | undefined,
+): AutoApprovalInfo | null {
+        if (!metadata) return null;
+        const raw = metadata.auto_approval;
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+
+        const info = raw as Record<string, unknown>;
+        const reason = typeof info.reason === "string" ? info.reason : null;
+        if (!reason) return null;
+
+        const providerId = typeof info.provider_id === "string" ? info.provider_id : null;
+        const at = typeof info.at === "string" ? info.at : null;
+
+        return {
+                reason,
+                providerId,
+                at,
+                trustedProvider: reason === "trusted_provider",
+        } satisfies AutoApprovalInfo;
+}
 
 const listInputSchema = filterSchema.extend({
 	page: z.number().int().min(1).optional(),
@@ -257,10 +286,13 @@ function buildEventFilters(filters: EventFilterInput): SQL[] {
 }
 
 function mapEvent(row: EventSelection) {
-	return {
-		id: row.id,
-		providerId: row.providerId,
-		flagId: row.flagId,
+        const metadata = (row.metadata ?? {}) as Record<string, unknown>;
+        const autoApproval = parseAutoApproval(metadata);
+
+        return {
+                id: row.id,
+                providerId: row.providerId,
+                flagId: row.flagId,
 		title: row.title,
 		description: row.description,
 		location: row.location,
@@ -270,7 +302,8 @@ function mapEvent(row: EventSelection) {
 		isAllDay: row.isAllDay,
 		isPublished: row.isPublished,
 		externalId: row.externalId,
-		metadata: row.metadata ?? {},
+                metadata,
+                autoApproval,
 		status: row.status,
 		priority: row.priority,
 		createdAt: row.createdAt,

--- a/apps/worker/src/db/providers.ts
+++ b/apps/worker/src/db/providers.ts
@@ -3,28 +3,30 @@ import { sql } from "bun";
 import type { ProviderRecord } from "../types/provider";
 
 interface RawProviderRow {
-	id: string;
-	name: string;
-	description: string | null;
-	category: string;
-	status: string;
-	config: Record<string, unknown> | null;
+        id: string;
+        name: string;
+        description: string | null;
+        category: string;
+        status: string;
+        config: Record<string, unknown> | null;
+        trusted: boolean;
 }
 
 function normalizeProvider(row: RawProviderRow): ProviderRecord {
-	return {
-		id: row.id,
-		name: row.name,
-		description: row.description,
-		category: row.category,
-		status: row.status as ProviderRecord["status"],
-		config: (row.config ?? {}) as ProviderRecord["config"],
-	};
+        return {
+                id: row.id,
+                name: row.name,
+                description: row.description,
+                category: row.category,
+                status: row.status as ProviderRecord["status"],
+                trusted: Boolean(row.trusted),
+                config: (row.config ?? {}) as ProviderRecord["config"],
+        };
 }
 
 export async function getActiveProviders(): Promise<ProviderRecord[]> {
-	const rows = await sql<RawProviderRow[]>`
-    SELECT id, name, description, category, status, config
+        const rows = await sql<RawProviderRow[]>`
+    SELECT id, name, description, category, status, config, trusted
     FROM provider
     WHERE status = 'active'
   `;

--- a/apps/worker/src/imap/session.ts
+++ b/apps/worker/src/imap/session.ts
@@ -131,19 +131,30 @@ async function handleMessage(
 			internalDate,
 		});
 
-	const metadata = {
-		...(extraction.metadata ?? {}),
-		imap_uid: uid,
-		mailbox,
-		message_id: messageId ?? null,
-		internal_date: internalDate ? internalDate.toISOString() : null,
-	};
+        const metadata = {
+                ...(extraction.metadata ?? {}),
+                imap_uid: uid,
+                mailbox,
+                message_id: messageId ?? null,
+                internal_date: internalDate ? internalDate.toISOString() : null,
+        } as Record<string, unknown>;
 
-	const inserted = await insertEvent({
-		...extraction,
-		external_id: externalId,
-		metadata,
-	});
+        const status = provider.trusted ? "approved" : extraction.status ?? "pending";
+
+        if (provider.trusted) {
+                metadata.auto_approval = {
+                        reason: "trusted_provider",
+                        provider_id: provider.id,
+                        at: new Date().toISOString(),
+                } satisfies Record<string, unknown>;
+        }
+
+        const inserted = await insertEvent({
+                ...extraction,
+                status,
+                external_id: externalId,
+                metadata,
+        });
 
 	if (!inserted) {
 		log.debug("Event already existed", {

--- a/apps/worker/src/types/provider.ts
+++ b/apps/worker/src/types/provider.ts
@@ -39,10 +39,11 @@ export interface ProviderConfig {
 }
 
 export interface ProviderRecord {
-	id: string;
-	name: string;
-	description?: string | null;
-	category: string;
-	status: ProviderStatus;
-	config: ProviderConfig;
+        id: string;
+        name: string;
+        description?: string | null;
+        category: string;
+        status: ProviderStatus;
+        trusted: boolean;
+        config: ProviderConfig;
 }


### PR DESCRIPTION
## Summary
- add a trusted flag to providers with a migration and expose it through the admin API
- let admins toggle trust in the provider forms and show trust badges in the catalog list
- auto-approve events from trusted providers in the worker and surface auto-approval details in the moderation UI

## Testing
- bun run --filter server check-types *(fails: No packages matched the filter)*

------
https://chatgpt.com/codex/tasks/task_b_68dbe4621b248327b8e8156275df1ae3