### PR TITLE
feat(worker): make fake extractor configurable

### DIFF
--- a/WIKI.md
+++ b/WIKI.md
@@ -147,6 +147,7 @@ flowchart TD
 | `WORKER_IDLE_KEEPALIVE_MS`        | `15000`  | IMAP idle heartbeat to avoid server disconnects.             |
 | `WORKER_BACKOFF_MIN_MS`           | `1000`   | Starting delay for exponential backoff.                      |
 | `WORKER_BACKOFF_MAX_MS`           | `60000`  | Maximum delay between reconnect attempts.                    |
+| `WORKER_USE_FAKE_EXTRACTOR`       | `false`  | Enables the Faker-based email parser when AI credentials are unavailable. |
 | `GOOGLE_GENERATIVE_AI_API_KEY`    | —        | Required by the AI SDK when enabling real Gemini extraction. |
 
 **Deployment Notes**
@@ -175,7 +176,7 @@ flowchart TD
 
 ## 11. Known Gaps & Future Work
 
-- The worker’s AI extraction currently references a Faker-based stub (`extractEventFromEmailFake`) because `IS_DEV` is hard-coded to `true`. Flip to the Gemini-backed parser when production credentials are ready.
+- The worker’s AI extraction defaults to Gemini but can fall back to the Faker-based stub (`extractEventFromEmailFake`) by setting `WORKER_USE_FAKE_EXTRACTOR=true` when the Gemini API key is unavailable.
 - Provider UI lacks detail views for linked organizations or historical test results; consider extending schema to capture audit trails.
 - Change-log alignment awaits the official PDF; until then, any signed-off scope changes must be tracked manually.
 - Flag usage is defined but events currently insert with `flag_id = null`; extend ingestion or admin workflows to classify events post-ingest.

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -1,12 +1,18 @@
+# CalendarSync worker environment example
+# Rename to .env and adjust values for your deployment.
 
-OPENAI_API_KEY=
-DATABASE_URL=
-GOOGLE_GENERATIVE_AI_API_KEY=
-ANTHROPIC_API_KEY=
-IMAP_HOST=
-IMAP_PORT=993
-IMAP_SECURE=true
-IMAP_USER=
-IMAP_PASS=
-IMAP_MAILBOX=INBOX
+# Shared services
+DATABASE_URL="postgres://user:password@localhost:5432/calendarsync"
 
+# Gemini API key (leave unset if using the fake extractor)
+GOOGLE_GENERATIVE_AI_API_KEY=""
+
+# Worker behaviour tuning
+WORKER_MAX_CONCURRENT_PROVIDERS=5
+WORKER_POLL_INTERVAL_MS=300000
+WORKER_IDLE_KEEPALIVE_MS=15000
+WORKER_BACKOFF_MIN_MS=1000
+WORKER_BACKOFF_MAX_MS=60000
+
+# Set to true to force the Faker-based extractor when Gemini access is unavailable
+WORKER_USE_FAKE_EXTRACTOR=false

--- a/apps/worker/src/config/env.ts
+++ b/apps/worker/src/config/env.ts
@@ -1,11 +1,11 @@
 import { logger } from "../services/log";
 
 function parseIntEnv(name: string, defaultValue: number): number {
-	const raw = process.env[name];
-	if (!raw) return defaultValue;
-	const parsed = Number.parseInt(raw, 10);
-	if (Number.isNaN(parsed)) {
-		logger.warn("Invalid numeric environment value", {
+        const raw = process.env[name];
+        if (!raw) return defaultValue;
+        const parsed = Number.parseInt(raw, 10);
+        if (Number.isNaN(parsed)) {
+                logger.warn("Invalid numeric environment value", {
 			source: "config",
 			name,
 			rawValue: raw,
@@ -16,12 +16,34 @@ function parseIntEnv(name: string, defaultValue: number): number {
 	return parsed;
 }
 
+function parseBooleanEnv(name: string, defaultValue: boolean): boolean {
+        const raw = process.env[name];
+        if (raw == null) return defaultValue;
+
+        const normalized = raw.trim().toLowerCase();
+        if (normalized === "true" || normalized === "1") {
+                return true;
+        }
+        if (normalized === "false" || normalized === "0") {
+                return false;
+        }
+
+        logger.warn("Invalid boolean environment value", {
+                source: "config",
+                name,
+                rawValue: raw,
+                defaultValue,
+        });
+        return defaultValue;
+}
+
 export interface WorkerConfig {
-	maxConcurrentProviders: number;
-	pollIntervalMs: number;
-	idleKeepaliveMs: number;
-	backoffMinMs: number;
-	backoffMaxMs: number;
+        maxConcurrentProviders: number;
+        pollIntervalMs: number;
+        idleKeepaliveMs: number;
+        backoffMinMs: number;
+        backoffMaxMs: number;
+        useFakeExtractor: boolean;
 }
 
 let cached: WorkerConfig | null = null;
@@ -31,22 +53,23 @@ export function getWorkerConfig(): WorkerConfig {
 		return cached;
 	}
 
-	cached = {
-		maxConcurrentProviders: Math.max(
-			1,
-			parseIntEnv("WORKER_MAX_CONCURRENT_PROVIDERS", 5),
-		),
+        cached = {
+                maxConcurrentProviders: Math.max(
+                        1,
+                        parseIntEnv("WORKER_MAX_CONCURRENT_PROVIDERS", 5),
+                ),
 		pollIntervalMs: Math.max(
 			1_000,
 			parseIntEnv("WORKER_POLL_INTERVAL_MS", 300_000),
-		),
-		idleKeepaliveMs: Math.max(
-			1_000,
-			parseIntEnv("WORKER_IDLE_KEEPALIVE_MS", 15_000),
-		),
-		backoffMinMs: Math.max(100, parseIntEnv("WORKER_BACKOFF_MIN_MS", 1_000)),
-		backoffMaxMs: Math.max(100, parseIntEnv("WORKER_BACKOFF_MAX_MS", 60_000)),
-	};
+                ),
+                idleKeepaliveMs: Math.max(
+                        1_000,
+                        parseIntEnv("WORKER_IDLE_KEEPALIVE_MS", 15_000),
+                ),
+                backoffMinMs: Math.max(100, parseIntEnv("WORKER_BACKOFF_MIN_MS", 1_000)),
+                backoffMaxMs: Math.max(100, parseIntEnv("WORKER_BACKOFF_MAX_MS", 60_000)),
+                useFakeExtractor: parseBooleanEnv("WORKER_USE_FAKE_EXTRACTOR", false),
+        };
 
 	if (cached.backoffMaxMs < cached.backoffMinMs) {
 		cached.backoffMaxMs = cached.backoffMinMs;

--- a/apps/worker/src/imap/session.ts
+++ b/apps/worker/src/imap/session.ts
@@ -11,14 +11,10 @@ import type { ImapConfig, ProviderRecord } from "../types/provider";
 import { extractEventFromEmail } from "../utils/mailparser";
 import { extractEventFromEmailFake } from "../utils/mailparser-test";
 
-const IS_DEV = true;
-const extractEvent = !IS_DEV
-	? extractEventFromEmail
-	: extractEventFromEmailFake;
 export interface ProviderSessionOptions {
-	workerConfig: WorkerConfig;
-	signal: AbortSignal;
-	logger: WorkerLogger;
+        workerConfig: WorkerConfig;
+        signal: AbortSignal;
+        logger: WorkerLogger;
 }
 
 const FETCH_OPTIONS = {
@@ -77,11 +73,14 @@ function synthesizeExternalId(params: {
 	].join(":");
 }
 
+type ExtractEventFn = typeof extractEventFromEmail;
+
 async function handleMessage(
-	provider: ProviderRecord,
-	mailbox: string,
-	message: FetchMessageObject,
-	log: WorkerLogger,
+        provider: ProviderRecord,
+        mailbox: string,
+        message: FetchMessageObject,
+        log: WorkerLogger,
+        extractEvent: ExtractEventFn,
 ): Promise<boolean> {
 	const uid = message.uid;
 	if (!uid) return false;
@@ -176,11 +175,11 @@ async function handleMessage(
 }
 
 export async function runProviderSession(
-	provider: ProviderRecord,
-	options: ProviderSessionOptions,
+        provider: ProviderRecord,
+        options: ProviderSessionOptions,
 ): Promise<void> {
-	const imapConfig = provider.config.imap;
-	if (!imapConfig) {
+        const imapConfig = provider.config.imap;
+        if (!imapConfig) {
 		options.logger.warn("Missing IMAP configuration");
 		return;
 	}
@@ -188,10 +187,14 @@ export async function runProviderSession(
 	const mailbox = resolveMailbox(imapConfig);
 	const { workerConfig, signal } = options;
 	const sessionLogger = options.logger;
-	const backoff = createBackoff({
-		minMs: workerConfig.backoffMinMs,
-		maxMs: workerConfig.backoffMaxMs,
-	});
+        const backoff = createBackoff({
+                minMs: workerConfig.backoffMinMs,
+                maxMs: workerConfig.backoffMaxMs,
+        });
+
+        const extractEvent: ExtractEventFn = workerConfig.useFakeExtractor
+                ? extractEventFromEmailFake
+                : extractEventFromEmail;
 
 	let stopRequested = signal.aborted;
 	const onAbort = () => {
@@ -267,12 +270,13 @@ export async function runProviderSession(
 						if (!message.uid) continue;
 
 						try {
-							const inserted = await handleMessage(
-								provider,
-								mailbox,
-								message,
-								sessionLogger,
-							);
+                                                        const inserted = await handleMessage(
+                                                                provider,
+                                                                mailbox,
+                                                                message,
+                                                                sessionLogger,
+                                                                extractEvent,
+                                                        );
 							if (inserted) processed += 1;
 						} catch (error) {
 							fetchRequested = true;


### PR DESCRIPTION
## Summary
- add a cached WORKER_USE_FAKE_EXTRACTOR flag to the worker config
- pick between the real and fake extractors at runtime using the new flag
- document the environment toggle and update the worker .env example

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68de50e4bd9c83278b676b01236cfadb