### PR TITLE
feat: add event landing pages and admin authoring

### DIFF
--- a/apps/server/src/app/events/[slug]/page.tsx
+++ b/apps/server/src/app/events/[slug]/page.tsx
@@ -1,0 +1,185 @@
+import type { Metadata } from "next";
+import { notFound, redirect } from "next/navigation";
+import { cache } from "react";
+import { and, eq } from "drizzle-orm";
+
+import { EventLandingDetails } from "@/components/events/EventLandingDetails";
+import { EventLandingHero } from "@/components/events/EventLandingHero";
+import { db } from "@/db";
+import { event } from "@/db/schema/app";
+import {
+        hasLandingContent,
+        parseHeroMedia,
+        parseLandingPage,
+} from "@/lib/event-content";
+import { buildAbsoluteUrl, getSiteBaseUrl } from "@/lib/site-metadata";
+
+const fetchPublishedEvent = cache(async (slug: string) => {
+        const rows = await db
+                .select({
+                        id: event.id,
+                        title: event.title,
+                        description: event.description,
+                        startAt: event.startAt,
+                        endAt: event.endAt,
+                        location: event.location,
+                        url: event.url,
+                        heroMedia: event.heroMedia,
+                        landingPage: event.landingPage,
+                        metadata: event.metadata,
+                        updatedAt: event.updatedAt,
+                        createdAt: event.createdAt,
+                        isPublished: event.isPublished,
+                        status: event.status,
+                })
+                .from(event)
+                .where(
+                        and(
+                                eq(event.slug, slug),
+                                eq(event.isPublished, true),
+                                eq(event.status, "approved"),
+                        ),
+                )
+                .limit(1);
+
+        const row = rows.at(0);
+        if (!row) return null;
+
+        return {
+                id: row.id,
+                slug,
+                title: row.title,
+                description: row.description,
+                startAt: row.startAt,
+                endAt: row.endAt,
+                location: row.location,
+                url: row.url,
+                heroMedia: parseHeroMedia(row.heroMedia),
+                landingPage: parseLandingPage(row.landingPage),
+                metadata: row.metadata ?? {},
+                updatedAt: row.updatedAt,
+                createdAt: row.createdAt,
+        } as const;
+});
+
+export async function generateStaticParams() {
+        const rows = await db
+                .select({ slug: event.slug })
+                .from(event)
+                .where(and(eq(event.isPublished, true), eq(event.status, "approved")));
+        return rows.map((row) => ({ slug: row.slug }));
+}
+
+export async function generateMetadata({
+        params,
+}: {
+        params: { slug: string };
+}): Promise<Metadata> {
+        const record = await fetchPublishedEvent(params.slug);
+        if (!record) {
+                return {
+                        title: "Event not found",
+                } satisfies Metadata;
+        }
+
+        const canonical = buildAbsoluteUrl(`/events/${record.slug}`);
+        const baseTitle = record.landingPage?.headline ?? record.title;
+        const description =
+                record.landingPage?.seoDescription ??
+                record.landingPage?.subheadline ??
+                record.description ??
+                undefined;
+        const hero = record.heroMedia;
+        const images =
+                hero?.type === "image" && hero.url ? [{ url: hero.url }] : undefined;
+        const videos =
+                hero?.type === "video" && hero.url
+                        ? [
+                                  {
+                                          url: hero.url,
+                                          width: 1280,
+                                          height: 720,
+                                          alt: hero.alt,
+                                  },
+                          ]
+                        : undefined;
+
+        return {
+                metadataBase: new URL(getSiteBaseUrl()),
+                title: baseTitle,
+                description,
+                alternates: {
+                        canonical,
+                },
+                openGraph: {
+                        title: baseTitle,
+                        description,
+                        url: canonical,
+                        type: "event",
+                        images,
+                        videos,
+                        startTime: record.startAt?.toISOString(),
+                        endTime: record.endAt?.toISOString(),
+                        locale: "en_US",
+                },
+                twitter: {
+                        card: images?.length ? "summary_large_image" : "summary",
+                        title: baseTitle,
+                        description,
+                        images: images?.map((image) => image.url),
+                },
+        } satisfies Metadata;
+}
+
+export default async function EventLandingPage({
+        params,
+}: {
+        params: { slug: string };
+}) {
+        const record = await fetchPublishedEvent(params.slug);
+        if (!record) notFound();
+
+        const hasRichContent =
+                hasLandingContent(record.landingPage) || Boolean(record.heroMedia?.url);
+
+        if (!hasRichContent) {
+                if (record.url) {
+                        redirect(record.url);
+                }
+                notFound();
+        }
+
+        const ctaHref = record.landingPage?.cta?.href ?? record.url ?? null;
+        const ctaLabel = record.landingPage?.cta?.label ?? (ctaHref ? "Visit event site" : null);
+
+        return (
+                <main className="flex min-h-screen flex-col bg-background">
+                        <EventLandingHero
+                                title={record.title}
+                                startAt={record.startAt}
+                                endAt={record.endAt}
+                                heroMedia={record.heroMedia}
+                                landing={record.landingPage}
+                                actionSlot=
+                                        ctaHref && ctaLabel ? (
+                                                <a
+                                                        className="inline-flex items-center gap-2 rounded-md bg-white px-4 py-2 text-sm font-medium text-black shadow hover:bg-white/90"
+                                                        href={ctaHref}
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                >
+                                                        {ctaLabel}
+                                                </a>
+                                        ) : undefined
+                        />
+                        <EventLandingDetails
+                                description={record.description}
+                                landing={record.landingPage}
+                                startAt={record.startAt}
+                                endAt={record.endAt}
+                                location={record.location}
+                                fallbackUrl={record.url}
+                        />
+                </main>
+        );
+}

--- a/apps/server/src/app/layout.tsx
+++ b/apps/server/src/app/layout.tsx
@@ -3,9 +3,9 @@ import "@/styles/globals.css";
 import type { Metadata, Viewport } from "next";
 // import { Geist, Geist_Mono } from "next/font/google"
 import type { ReactNode } from "react";
-import { Providers } from "./providers";
 
-// import { Header } from "@/components/header"
+import { getSiteBaseUrl } from "@/lib/site-metadata";
+import { Providers } from "./providers";
 
 const geistSans = Geist({
 	variable: "--font-geist-sans",
@@ -17,9 +17,15 @@ const geistMono = Geist_Mono({
 	subsets: ["latin"],
 });
 
+const siteBaseUrl = getSiteBaseUrl();
+
 export const metadata: Metadata = {
-	title: "Next.js Starter",
-	description: "Next.js Starter ",
+        metadataBase: new URL(siteBaseUrl),
+        title: {
+                default: "CalendarSync",
+                template: "%s | CalendarSync",
+        },
+        description: "CalendarSync helps teams publish curated events with rich landing pages.",
 };
 
 export const viewport: Viewport = {

--- a/apps/server/src/app/sitemap.ts
+++ b/apps/server/src/app/sitemap.ts
@@ -1,0 +1,35 @@
+import type { MetadataRoute } from "next";
+import { and, eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import { event } from "@/db/schema/app";
+import { buildAbsoluteUrl } from "@/lib/site-metadata";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+        const staticRoutes: MetadataRoute.Sitemap = [
+                {
+                        url: buildAbsoluteUrl("/"),
+                },
+                {
+                        url: buildAbsoluteUrl("/contact"),
+                },
+                {
+                        url: buildAbsoluteUrl("/privacy"),
+                },
+                {
+                        url: buildAbsoluteUrl("/terms"),
+                },
+        ];
+
+        const rows = await db
+                .select({ slug: event.slug, updatedAt: event.updatedAt, createdAt: event.createdAt })
+                .from(event)
+                .where(and(eq(event.isPublished, true), eq(event.status, "approved")));
+
+        const eventRoutes: MetadataRoute.Sitemap = rows.map((row) => ({
+                url: buildAbsoluteUrl(`/events/${row.slug}`),
+                lastModified: (row.updatedAt ?? row.createdAt)?.toISOString?.() ?? undefined,
+        }));
+
+        return [...staticRoutes, ...eventRoutes];
+}

--- a/apps/server/src/components/admin/events/EventActionsMenu.tsx
+++ b/apps/server/src/components/admin/events/EventActionsMenu.tsx
@@ -15,42 +15,54 @@ import {
 import type { StatusAction } from "./status-actions";
 
 type EventActionsMenuProps = {
-	statusActions: StatusAction[];
-	onUpdateStatus: (status: StatusAction["status"]) => void;
-	onEdit: () => void;
-	onView: () => void;
-	disabled?: boolean;
+        statusActions: StatusAction[];
+        onUpdateStatus: (status: StatusAction["status"]) => void;
+        onEdit: () => void;
+        onView: () => void;
+        disabled?: boolean;
+        onDelete: () => void;
+        isDeleting?: boolean;
 };
 
 export function EventActionsMenu({
-	statusActions,
-	onUpdateStatus,
-	onEdit,
-	onView,
-	disabled = false,
+        statusActions,
+        onUpdateStatus,
+        onEdit,
+        onView,
+        onDelete,
+        isDeleting = false,
+        disabled = false,
 }: EventActionsMenuProps) {
-	return (
-		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<Button variant="ghost" size="icon" disabled={disabled}>
+        return (
+                <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                                <Button variant="ghost" size="icon" disabled={disabled}>
 					<MoreHorizontal className="size-4" />
 				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="end" className="w-48">
 				<DropdownMenuLabel>Moderation</DropdownMenuLabel>
-				{statusActions.map((action) => (
-					<DropdownMenuItem
-						key={action.status}
-						onClick={() => onUpdateStatus(action.status)}
-					>
-						<action.icon className="mr-2 size-4" />
-						{action.label}
-					</DropdownMenuItem>
-				))}
-				<DropdownMenuSeparator />
-				<DropdownMenuItem onClick={onEdit}>Edit event</DropdownMenuItem>
-				<DropdownMenuItem onClick={onView}>View details</DropdownMenuItem>
-			</DropdownMenuContent>
-		</DropdownMenu>
-	);
+                                {statusActions.map((action) => (
+                                        <DropdownMenuItem
+                                                key={action.status}
+                                                onClick={() => onUpdateStatus(action.status)}
+                                        >
+                                                <action.icon className="mr-2 size-4" />
+                                                {action.label}
+                                        </DropdownMenuItem>
+                                ))}
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem onClick={onEdit}>Edit event</DropdownMenuItem>
+                                <DropdownMenuItem onClick={onView}>View details</DropdownMenuItem>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem
+                                        onClick={onDelete}
+                                        disabled={isDeleting}
+                                        className="text-destructive focus:text-destructive"
+                                >
+                                        Delete event
+                                </DropdownMenuItem>
+                        </DropdownMenuContent>
+                </DropdownMenu>
+        );
 }

--- a/apps/server/src/components/admin/events/EventListView.tsx
+++ b/apps/server/src/components/admin/events/EventListView.tsx
@@ -21,25 +21,29 @@ import { statusActions } from "./status-actions";
 import type { EventListItem } from "./types";
 
 export type EventListViewProps = {
-	events: EventListItem[];
-	view: "table" | "card";
-	selectedIds: string[];
-	onSelect: (id: string, checked: boolean) => void;
-	onSelectAll: (checked: boolean) => void;
-	onEdit: (event: EventListItem) => void;
-	onViewDetail: (id: string) => void;
-	onStatusAction: (id: string, status: EventListItem["status"]) => void;
+        events: EventListItem[];
+        view: "table" | "card";
+        selectedIds: string[];
+        onSelect: (id: string, checked: boolean) => void;
+        onSelectAll: (checked: boolean) => void;
+        onEdit: (event: EventListItem) => void;
+        onViewDetail: (id: string) => void;
+        onStatusAction: (id: string, status: EventListItem["status"]) => void;
+        onDelete: (event: EventListItem) => void;
+        isDeleting: boolean;
 };
 
 export function EventListView({
-	events,
-	view,
-	selectedIds,
-	onSelect,
-	onSelectAll,
-	onEdit,
-	onViewDetail,
-	onStatusAction,
+        events,
+        view,
+        selectedIds,
+        onSelect,
+        onSelectAll,
+        onEdit,
+        onViewDetail,
+        onStatusAction,
+        onDelete,
+        isDeleting,
 }: EventListViewProps) {
 	const selectedIdSet = new Set(selectedIds);
 	const allSelectedOnPage =
@@ -92,16 +96,19 @@ export function EventListView({
 											</CardTitle>
 										}
 									/>
-									<EventActionsMenu
-										statusActions={statusActions}
-										onUpdateStatus={(status) =>
-											onStatusAction(event.id, status)
-										}
-										onEdit={() => onEdit(event)}
-										onView={() => onViewDetail(event.id)}
-									/>
-								</div>
-							</CardHeader>
+                                                                        <EventActionsMenu
+                                                                                statusActions={statusActions}
+                                                                                onUpdateStatus={(status) =>
+                                                                                        onStatusAction(event.id, status)
+                                                                                }
+                                                                                onEdit={() => onEdit(event)}
+                                                                                onView={() => onViewDetail(event.id)}
+                                                                                onDelete={() => onDelete(event)}
+                                                                                isDeleting={isDeleting}
+                                                                                disabled={isDeleting}
+                                                                        />
+                                                                </div>
+                                                        </CardHeader>
 							<CardContent className="flex flex-1 flex-col gap-4">
 								<div className="flex flex-wrap gap-2 text-muted-foreground text-xs sm:text-sm">
 									<span className="flex items-center gap-2 rounded-md border bg-muted/60 px-2 py-1">
@@ -211,19 +218,22 @@ export function EventListView({
 										{event.isPublished ? "Published" : "Draft"}
 									</Badge>
 								</TableCell>
-								<TableCell className="text-right">
-									<EventActionsMenu
-										statusActions={statusActions}
-										onUpdateStatus={(status) =>
-											onStatusAction(event.id, status)
-										}
-										onEdit={() => onEdit(event)}
-										onView={() => onViewDetail(event.id)}
-									/>
-								</TableCell>
-							</TableRow>
-						);
-					})}
+                                                                <TableCell className="text-right">
+                                                                        <EventActionsMenu
+                                                                                statusActions={statusActions}
+                                                                                onUpdateStatus={(status) =>
+                                                                                        onStatusAction(event.id, status)
+                                                                                }
+                                                                                onEdit={() => onEdit(event)}
+                                                                                onView={() => onViewDetail(event.id)}
+                                                                                onDelete={() => onDelete(event)}
+                                                                                isDeleting={isDeleting}
+                                                                                disabled={isDeleting}
+                                                                        />
+                                                                </TableCell>
+                                                        </TableRow>
+                                                );
+                                        })}
 				</TableBody>
 			</Table>
 		</div>

--- a/apps/server/src/components/admin/events/EventPreview.tsx
+++ b/apps/server/src/components/admin/events/EventPreview.tsx
@@ -48,20 +48,26 @@ export function EventPreview({
 		layout === "card"
 			? (event.location ?? "No location")
 			: (event.location ?? "");
-	const shouldRenderBadges =
-		Boolean(badgePrefix) ||
-		inlineTitle ||
-		event.isAllDay ||
-		Boolean(event.flag) ||
-		Boolean(event.autoApproval);
+        const shouldRenderBadges =
+                Boolean(badgePrefix) ||
+                inlineTitle ||
+                event.isAllDay ||
+                Boolean(event.slug) ||
+                Boolean(event.flag) ||
+                Boolean(event.autoApproval);
 
 	return (
 		<div className={cn(containerClasses, className)}>
 			{titleSlot && !inlineTitle ? titleSlot : null}
 			{shouldRenderBadges ? (
 				<div className={badgeRowClasses}>
-					{badgePrefix}
-					{inlineTitle ? titleContent : null}
+                                        {badgePrefix}
+                                        {event.slug ? (
+                                                <Badge variant="outline" className="font-mono text-[10px] uppercase">
+                                                        {event.slug}
+                                                </Badge>
+                                        ) : null}
+                                        {inlineTitle ? titleContent : null}
 					{event.isAllDay ? (
 						<Badge variant="outline" className="uppercase">
 							All-day

--- a/apps/server/src/components/events/EventLandingDetails.tsx
+++ b/apps/server/src/components/events/EventLandingDetails.tsx
@@ -1,0 +1,94 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import type { EventLandingPageContent } from "@/lib/event-content";
+import { formatDisplayDate } from "@/lib/datetime";
+
+function splitParagraphs(body: string | null | undefined) {
+        if (!body) return [];
+        const trimmed = body.trim();
+        if (trimmed.length === 0) return [];
+        return trimmed.split(/\n{2,}/);
+}
+
+type EventLandingDetailsProps = {
+        description: string | null;
+        landing: EventLandingPageContent | null;
+        startAt: Date;
+        endAt: Date | null;
+        location: string | null;
+        fallbackUrl: string | null;
+};
+
+export function EventLandingDetails({
+        description,
+        landing,
+        startAt,
+        endAt,
+        location,
+        fallbackUrl,
+}: EventLandingDetailsProps) {
+        const paragraphs = splitParagraphs(landing?.body);
+        const ctaHref = landing?.cta?.href ?? fallbackUrl ?? null;
+        const ctaLabel = landing?.cta?.label ?? (ctaHref ? "Visit event site" : null);
+
+        return (
+                <section className="container mx-auto grid gap-8 px-6 py-12 sm:px-12">
+                        <Card>
+                                <CardContent className="grid gap-6 px-6 py-8 sm:grid-cols-2">
+                                        <div className="space-y-3 text-sm">
+                                                <p className="font-semibold text-base text-foreground">Schedule</p>
+                                                <p className="text-muted-foreground">Starts: {formatDisplayDate(startAt)}</p>
+                                                {endAt ? (
+                                                        <p className="text-muted-foreground">
+                                                                Ends: {formatDisplayDate(endAt)}
+                                                        </p>
+                                                ) : null}
+                                                {location ? (
+                                                        <p className="text-muted-foreground">Location: {location}</p>
+                                                ) : null}
+                                        </div>
+                                        <div className="space-y-3 text-sm">
+                                                {description ? (
+                                                        <div className="space-y-2">
+                                                                <p className="font-semibold text-base text-foreground">
+                                                                        Overview
+                                                                </p>
+                                                                <p className="whitespace-pre-wrap text-muted-foreground">
+                                                                        {description}
+                                                                </p>
+                                                        </div>
+                                                ) : null}
+                                                {paragraphs.length > 0 ? (
+                                                        <div className="space-y-2">
+                                                                <p className="font-semibold text-base text-foreground">
+                                                                        Details
+                                                                </p>
+                                                                <div className="space-y-3 text-muted-foreground">
+                                                                        {paragraphs.map((paragraph, index) => (
+                                                                                <p key={index} className="whitespace-pre-wrap leading-relaxed">
+                                                                                        {paragraph}
+                                                                                </p>
+                                                                        ))}
+                                                                </div>
+                                                        </div>
+                                                ) : null}
+                                                {landing?.seoDescription ? (
+                                                        <p className="text-muted-foreground text-xs">
+                                                                {landing.seoDescription}
+                                                        </p>
+                                                ) : null}
+                                                {ctaHref && ctaLabel ? (
+                                                        <Button asChild className="mt-2 w-fit">
+                                                                <Link href={ctaHref} target="_blank" rel="noopener noreferrer">
+                                                                        {ctaLabel}
+                                                                </Link>
+                                                        </Button>
+                                                ) : null}
+                                        </div>
+                                </CardContent>
+                        </Card>
+                </section>
+        );
+}

--- a/apps/server/src/components/events/EventLandingHero.tsx
+++ b/apps/server/src/components/events/EventLandingHero.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from "react";
+
+import type { EventHeroMedia, EventLandingPageContent } from "@/lib/event-content";
+import { formatDisplayDate } from "@/lib/datetime";
+
+type EventLandingHeroProps = {
+        title: string;
+        startAt: Date;
+        endAt: Date | null;
+        heroMedia: EventHeroMedia | null;
+        landing: EventLandingPageContent | null;
+        actionSlot?: ReactNode;
+};
+
+export function EventLandingHero({
+        title,
+        startAt,
+        endAt,
+        heroMedia,
+        landing,
+        actionSlot,
+}: EventLandingHeroProps) {
+        const headline = landing?.headline ?? title;
+        const subheadline = landing?.subheadline ?? null;
+        return (
+                <section className="hero-gradient relative overflow-hidden">
+                        <div className="absolute inset-0 bg-black/30" aria-hidden />
+                        {heroMedia?.url ? (
+                                heroMedia.type === "video" ? (
+                                        <video
+                                                className="absolute inset-0 h-full w-full object-cover"
+                                                src={heroMedia.url}
+                                                poster={heroMedia.posterUrl ?? undefined}
+                                                autoPlay
+                                                loop
+                                                muted
+                                                playsInline
+                                        />
+                                ) : (
+                                        <img
+                                                src={heroMedia.url}
+                                                alt={heroMedia.alt ?? "Event hero media"}
+                                                className="absolute inset-0 h-full w-full object-cover"
+                                        />
+                                )
+                        ) : null}
+                        <div className="relative z-10 mx-auto flex max-w-5xl flex-col gap-6 px-6 py-16 text-white sm:px-12">
+                                <p className="text-sm uppercase tracking-wide text-white/80">
+                                        {formatDisplayDate(startAt)}
+                                        {endAt ? ` – ${formatDisplayDate(endAt)}` : ""}
+                                </p>
+                                <h1 className="max-w-3xl text-balance font-semibold text-4xl tracking-tight sm:text-5xl">
+                                        {headline}
+                                </h1>
+                                {subheadline ? (
+                                        <p className="max-w-3xl text-balance text-lg text-white/80 sm:text-xl">
+                                                {subheadline}
+                                        </p>
+                                ) : null}
+                                {actionSlot ? <div className="flex flex-wrap gap-3">{actionSlot}</div> : null}
+                        </div>
+                </section>
+        );
+}

--- a/apps/server/src/components/events/EventsCalendar.tsx
+++ b/apps/server/src/components/events/EventsCalendar.tsx
@@ -302,6 +302,13 @@ export function EventsCalendar({
                   </div>
                 </ScrollArea>
                 <DialogFooter className="gap-2">
+                  {selectedEvent.slug ? (
+                    <Button asChild>
+                      <Link href={`/events/${selectedEvent.slug}`} target="_blank" rel="noopener noreferrer">
+                        <LinkIcon className="mr-2 size-4" aria-hidden /> View landing page
+                      </Link>
+                    </Button>
+                  ) : null}
                   {selectedEvent.url ? (
                     <Button asChild variant="outline">
                       <Link

--- a/apps/server/src/db/migrations/0001_event_landing_pages.sql
+++ b/apps/server/src/db/migrations/0001_event_landing_pages.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "event" ADD COLUMN IF NOT EXISTS "slug" text;
+ALTER TABLE "event" ADD COLUMN IF NOT EXISTS "hero_media" jsonb NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE "event" ADD COLUMN IF NOT EXISTS "landing_page" jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+UPDATE "event"
+SET "slug" = CONCAT('event-', "id")
+WHERE "slug" IS NULL OR LENGTH(TRIM("slug")) = 0;
+
+ALTER TABLE "event" ALTER COLUMN "slug" SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "event_slug_unique" ON "event" ("slug");

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1759413124284,
       "tag": "0000_aspiring_james_howlett",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1759413124285,
+      "tag": "0001_event_landing_pages",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema/app.ts
+++ b/apps/server/src/db/schema/app.ts
@@ -90,21 +90,30 @@ export const flag = pgTable(
 );
 
 export const event = pgTable(
-	"event",
-	{
-		id: text("id").primaryKey(),
-		provider: text("provider_id")
-			.notNull()
-			.references(() => provider.id, { onDelete: "set null" }),
-		flag: text("flag_id").references(() => flag.id, { onDelete: "set null" }),
-		title: text("title").notNull(),
-		description: text("description"),
-		location: text("location"),
-		url: text("url"),
-		startAt: timestamp("start_at", { withTimezone: true }).notNull(),
-		endAt: timestamp("end_at", { withTimezone: true }),
-		isAllDay: boolean("is_all_day").default(false).notNull(),
-		isPublished: boolean("is_published").default(false).notNull(),
+        "event",
+        {
+                id: text("id").primaryKey(),
+                slug: text("slug").notNull(),
+                provider: text("provider_id")
+                        .notNull()
+                        .references(() => provider.id, { onDelete: "set null" }),
+                flag: text("flag_id").references(() => flag.id, { onDelete: "set null" }),
+                title: text("title").notNull(),
+                description: text("description"),
+                location: text("location"),
+                url: text("url"),
+                heroMedia: jsonb("hero_media")
+                        .$type<Record<string, unknown>>()
+                        .notNull()
+                        .default(sql`'{}'::jsonb`),
+                landingPage: jsonb("landing_page")
+                        .$type<Record<string, unknown>>()
+                        .notNull()
+                        .default(sql`'{}'::jsonb`),
+                startAt: timestamp("start_at", { withTimezone: true }).notNull(),
+                endAt: timestamp("end_at", { withTimezone: true }),
+                isAllDay: boolean("is_all_day").default(false).notNull(),
+                isPublished: boolean("is_published").default(false).notNull(),
 		externalId: text("external_id"),
 		metadata: jsonb("metadata")
 			.$type<Record<string, unknown>>()
@@ -118,9 +127,10 @@ export const event = pgTable(
 		...timestamps,
 	},
 	(table) => ({
-		eventProviderExternalIdUnique: uniqueIndex(
-			"event_provider_id_external_id_unique",
-		).on(table.provider, table.externalId),
+                eventSlugUnique: uniqueIndex("event_slug_unique").on(table.slug),
+                eventProviderExternalIdUnique: uniqueIndex(
+                        "event_provider_id_external_id_unique",
+                ).on(table.provider, table.externalId),
 		statusStartAtIdx: index("status_start_at_idx").on(
 			table.status,
 			desc(table.startAt),

--- a/apps/server/src/lib/event-content.ts
+++ b/apps/server/src/lib/event-content.ts
@@ -1,0 +1,95 @@
+export type EventHeroMediaType = "image" | "video";
+
+export type EventHeroMedia = {
+        type?: EventHeroMediaType;
+        url?: string;
+        alt?: string;
+        posterUrl?: string;
+};
+
+export type EventLandingPageCTA = {
+        label?: string;
+        href?: string;
+};
+
+export type EventLandingPageContent = {
+        headline?: string;
+        subheadline?: string;
+        body?: string;
+        seoDescription?: string;
+        cta?: EventLandingPageCTA;
+};
+
+export function parseHeroMedia(value: unknown): EventHeroMedia {
+        if (!value || typeof value !== "object" || Array.isArray(value)) {
+                return {};
+        }
+
+        const raw = value as Record<string, unknown>;
+        const type = raw.type === "image" || raw.type === "video" ? raw.type : undefined;
+        const url = typeof raw.url === "string" ? raw.url : undefined;
+        const alt = typeof raw.alt === "string" ? raw.alt : undefined;
+        const posterUrl = typeof raw.posterUrl === "string" ? raw.posterUrl : undefined;
+
+        const result: EventHeroMedia = {};
+        if (type) result.type = type;
+        if (url) result.url = url;
+        if (alt) result.alt = alt;
+        if (posterUrl) result.posterUrl = posterUrl;
+
+        return result;
+}
+
+export function parseLandingPage(value: unknown): EventLandingPageContent {
+        if (!value || typeof value !== "object" || Array.isArray(value)) {
+                return {};
+        }
+
+        const raw = value as Record<string, unknown>;
+
+        const result: EventLandingPageContent = {};
+        if (typeof raw.headline === "string" && raw.headline.trim().length > 0) {
+                result.headline = raw.headline;
+        }
+        if (typeof raw.subheadline === "string" && raw.subheadline.trim().length > 0) {
+                result.subheadline = raw.subheadline;
+        }
+        if (typeof raw.body === "string" && raw.body.trim().length > 0) {
+                result.body = raw.body;
+        }
+        if (typeof raw.seoDescription === "string" && raw.seoDescription.trim().length > 0) {
+                result.seoDescription = raw.seoDescription;
+        }
+
+        const ctaValue = raw.cta;
+        if (ctaValue && typeof ctaValue === "object" && !Array.isArray(ctaValue)) {
+                const ctaRecord = ctaValue as Record<string, unknown>;
+                const label =
+                        typeof ctaRecord.label === "string" && ctaRecord.label.trim().length > 0
+                                ? ctaRecord.label
+                                : undefined;
+                const href =
+                        typeof ctaRecord.href === "string" && ctaRecord.href.trim().length > 0
+                                ? ctaRecord.href
+                                : undefined;
+                if (label || href) {
+                        result.cta = {};
+                        if (label) result.cta.label = label;
+                        if (href) result.cta.href = href;
+                }
+        }
+
+        return result;
+}
+
+export function hasLandingContent(content: EventLandingPageContent | null | undefined) {
+        if (!content) return false;
+        return Boolean(
+                content.headline ||
+                        content.subheadline ||
+                        content.body ||
+                        content.seoDescription ||
+                        content.cta?.label ||
+                        content.cta?.href,
+        );
+}

--- a/apps/server/src/lib/site-metadata.ts
+++ b/apps/server/src/lib/site-metadata.ts
@@ -1,0 +1,29 @@
+const FALLBACK_SITE_URL = "http://localhost:3000";
+
+function cleanBaseUrl(url: string) {
+        return url.replace(/\/$/, "");
+}
+
+export function getSiteBaseUrl(): string {
+        const candidate =
+                process.env.NEXT_PUBLIC_APP_URL ||
+                process.env.APP_BASE_URL ||
+                process.env.APP_URL ||
+                process.env.VERCEL_PROJECT_PRODUCTION_URL ||
+                process.env.VERCEL_URL;
+        if (!candidate) return FALLBACK_SITE_URL;
+        if (candidate.startsWith("http")) {
+                return cleanBaseUrl(candidate);
+        }
+        return cleanBaseUrl(`https://${candidate}`);
+}
+
+export function buildAbsoluteUrl(path: string): string {
+        const base = getSiteBaseUrl();
+        try {
+                return new URL(path, base).toString();
+        } catch (error) {
+                const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+                return `${base}${normalizedPath}`;
+        }
+}


### PR DESCRIPTION
## Summary
- extend event schema and utilities with slug, hero media, and landing page content support
- add tRPC CRUD mutations and update admin UI to manage event publishing, slugs, and landing metadata
- create public event landing route with metadata helpers and sitemap wiring for discoverability

## Testing
- `bun run --filter server build` *(fails: Next.js build cannot download remote Geist font assets in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_b_68e368b6e1fc8327b51554fa19ebab35