### PR TITLE
feat(admin): build attendee roster and event analytics tooling

### DIFF
--- a/apps/server/src/app/(site)/admin/events/[id]/attendees/page.tsx
+++ b/apps/server/src/app/(site)/admin/events/[id]/attendees/page.tsx
@@ -1,0 +1,846 @@
+"use client";
+
+import { RedirectToSignIn } from "@daveyplate/better-auth-ui";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
+import { formatDistanceToNow } from "date-fns";
+import { MoreHorizontal } from "lucide-react";
+import { useParams } from "next/navigation";
+import { useEffect, useId, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import AppShell from "@/components/layout/AppShell";
+import { UserAvatar } from "@/components/UserAvatar";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Pagination,
+	PaginationContent,
+	PaginationItem,
+	PaginationLink,
+	PaginationNext,
+	PaginationPrevious,
+} from "@/components/ui/pagination";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { eventKeys } from "@/lib/query-keys/events";
+import { trpcClient } from "@/lib/trpc-client";
+import type { AppRouter } from "@/routers";
+
+function useDebouncedValue<T>(value: T, delay = 400) {
+	const [debounced, setDebounced] = useState(value);
+	useEffect(() => {
+		const handle = setTimeout(() => setDebounced(value), delay);
+		return () => clearTimeout(handle);
+	}, [value, delay]);
+	return debounced;
+}
+
+type RouterInputs = inferRouterInputs<AppRouter>;
+type RouterOutputs = inferRouterOutputs<AppRouter>;
+
+type AttendeeListInput = RouterInputs["events"]["attendees"]["list"];
+type UpdateAttendeeStatusInput =
+	RouterInputs["events"]["attendees"]["updateStatus"];
+type AttendeeExportInput = RouterInputs["events"]["attendees"]["export"];
+type BulkAnnouncementInput = RouterInputs["events"]["attendees"]["announce"];
+
+type AttendeeListOutput = RouterOutputs["events"]["attendees"]["list"];
+type AttendeeListItem = AttendeeListOutput["items"][number];
+
+type EventDetailOutput = RouterOutputs["events"]["get"];
+
+const statusSegments = [
+	"all",
+	"registered",
+	"checked_in",
+	"waitlisted",
+	"cancelled",
+] as const;
+type StatusSegment = (typeof statusSegments)[number];
+
+const checkInFilters = ["all", "checked_in", "not_checked_in"] as const;
+type CheckInFilter = (typeof checkInFilters)[number];
+
+const statusLabels: Record<AttendeeListItem["status"], string> = {
+	reserved: "Reserved",
+	registered: "Registered",
+	checked_in: "Checked-in",
+	cancelled: "Cancelled",
+	waitlisted: "Waitlisted",
+};
+
+const statusVariants: Record<
+	AttendeeListItem["status"],
+	"default" | "secondary" | "outline" | "destructive"
+> = {
+	reserved: "outline",
+	registered: "secondary",
+	checked_in: "default",
+	cancelled: "destructive",
+	waitlisted: "secondary",
+};
+
+const pageSize = 25;
+
+const textareaStyles =
+	"min-h-32 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+
+export default function EventAttendeesPage() {
+	const params = useParams<{ id: string }>();
+	const rawEventId = params?.id;
+	const eventId = Array.isArray(rawEventId) ? rawEventId[0] : rawEventId;
+
+	const [page, setPage] = useState(1);
+	const [search, setSearch] = useState("");
+	const [statusSegment, setStatusSegment] = useState<StatusSegment>("all");
+	const [checkInFilter, setCheckInFilter] = useState<CheckInFilter>("all");
+	const [noShowOnly, setNoShowOnly] = useState(false);
+	const [sort, setSort] = useState<AttendeeListInput["sort"]>("created_desc");
+	const [isAnnouncementOpen, setAnnouncementOpen] = useState(false);
+	const [announcementSubject, setAnnouncementSubject] = useState("");
+	const [announcementMessage, setAnnouncementMessage] = useState("");
+	const [announcementAudience, setAnnouncementAudience] =
+		useState<BulkAnnouncementInput["audience"]>("all");
+	const idPrefix = useId();
+	const searchInputId = `${idPrefix}-search`;
+	const statusSelectId = `${idPrefix}-status`;
+	const checkInSelectId = `${idPrefix}-check-in`;
+	const sortSelectId = `${idPrefix}-sort`;
+	const noShowCheckboxId = `${idPrefix}-no-show`;
+	const audienceSelectId = `${idPrefix}-audience`;
+	const subjectInputId = `${idPrefix}-subject`;
+	const messageTextareaId = `${idPrefix}-message`;
+	const skeletonRowKeys = useMemo(
+		() =>
+			Array.from(
+				{ length: pageSize },
+				(_, index) => `${idPrefix}-loading-${index}`,
+			),
+		[idPrefix],
+	);
+
+	const debouncedSearch = useDebouncedValue(search);
+	const queryClient = useQueryClient();
+
+	const listParams = useMemo(() => {
+		if (!eventId) {
+			return null;
+		}
+		const params: AttendeeListInput = {
+			eventId,
+			page,
+			limit: pageSize,
+			sort,
+		};
+		if (debouncedSearch.trim().length > 0) {
+			params.q = debouncedSearch.trim();
+		}
+		if (statusSegment === "registered") {
+			params.status = ["registered", "reserved"];
+		} else if (statusSegment === "checked_in") {
+			params.status = ["checked_in"];
+		} else if (statusSegment === "waitlisted") {
+			params.status = ["waitlisted"];
+		} else if (statusSegment === "cancelled") {
+			params.status = ["cancelled"];
+		}
+		if (checkInFilter === "checked_in") {
+			params.checkedIn = "checked_in";
+		} else if (checkInFilter === "not_checked_in") {
+			params.checkedIn = "not_checked_in";
+		}
+		if (noShowOnly) {
+			params.noShow = true;
+		}
+		return params;
+	}, [
+		eventId,
+		page,
+		sort,
+		debouncedSearch,
+		statusSegment,
+		checkInFilter,
+		noShowOnly,
+	]);
+
+	const exportParams: AttendeeExportInput | null = useMemo(() => {
+		if (!listParams) return null;
+		const { eventId: exportEventId, status, checkedIn, noShow, q } = listParams;
+		const payload: AttendeeExportInput = { eventId: exportEventId };
+		if (status) payload.status = status;
+		if (checkedIn) payload.checkedIn = checkedIn;
+		if (noShow !== undefined) payload.noShow = noShow;
+		if (q) payload.q = q;
+		return payload;
+	}, [listParams]);
+
+	const eventQuery = useQuery<EventDetailOutput, Error>({
+		queryKey: [...eventKeys.all, "detail", eventId ?? "unknown"] as const,
+		queryFn: () => trpcClient.events.get.query({ id: eventId ?? "" }),
+		enabled: Boolean(eventId),
+	});
+
+	const attendeesQuery = useQuery<AttendeeListOutput, Error>({
+		queryKey: listParams
+			? eventKeys.attendees.list(listParams.eventId, listParams)
+			: ([
+					...eventKeys.attendees.root(eventId ?? "unknown"),
+					"list",
+					"idle",
+				] as const),
+		queryFn: () => {
+			if (!listParams) {
+				return Promise.resolve({
+					items: [],
+					total: 0,
+					page: 1,
+					limit: pageSize,
+				} as AttendeeListOutput);
+			}
+			return trpcClient.events.attendees.list.query(listParams);
+		},
+		enabled: Boolean(listParams),
+		keepPreviousData: true,
+	});
+
+	const updateStatusMutation = useMutation<
+		AttendeeListItem,
+		Error,
+		UpdateAttendeeStatusInput
+	>({
+		mutationFn: (variables) =>
+			trpcClient.events.attendees.updateStatus.mutate(variables),
+		onSuccess: () => {
+			toast.success("Attendee updated");
+			queryClient.invalidateQueries({
+				queryKey: eventKeys.attendees.root(eventId ?? ""),
+			});
+			queryClient.invalidateQueries({
+				queryKey: eventKeys.analytics.root(eventId ?? ""),
+			});
+		},
+		onError: (error: Error) => {
+			toast.error(error.message);
+		},
+	});
+
+	const exportMutation = useMutation({
+		mutationFn: (variables: AttendeeExportInput) =>
+			trpcClient.events.attendees.export.mutate(variables),
+		onSuccess: (data) => {
+			const blob = new Blob([data.csv], { type: "text/csv;charset=utf-8" });
+			const url = URL.createObjectURL(blob);
+			const link = document.createElement("a");
+			link.href = url;
+			link.download = data.filename;
+			document.body.appendChild(link);
+			link.click();
+			document.body.removeChild(link);
+			URL.revokeObjectURL(url);
+			toast.success(`Export ready (${data.count} rows)`);
+		},
+		onError: (error: Error) => {
+			toast.error(error.message);
+		},
+	});
+
+	const announcementMutation = useMutation({
+		mutationFn: (variables: BulkAnnouncementInput) =>
+			trpcClient.events.attendees.announce.mutate(variables),
+		onSuccess: (result) => {
+			toast.success(
+				`Queued ${result.queued} announcement${result.queued === 1 ? "" : "s"}`,
+			);
+			setAnnouncementOpen(false);
+			setAnnouncementMessage("");
+			setAnnouncementSubject("");
+			queryClient.invalidateQueries({
+				queryKey: eventKeys.analytics.root(eventId ?? ""),
+			});
+		},
+		onError: (error: Error) => {
+			toast.error(error.message);
+		},
+	});
+
+	useEffect(() => {
+		const total = attendeesQuery.data?.total ?? 0;
+		const limit = attendeesQuery.data?.limit ?? pageSize;
+		const totalPages = Math.max(1, Math.ceil(total / limit));
+		if (page > totalPages) {
+			setPage(totalPages);
+		}
+	}, [attendeesQuery.data, page]);
+
+	if (!eventId) {
+		return (
+			<AppShell
+				breadcrumbs={[{ label: "Admin", href: "/admin/overview" }]}
+				headerRight={<UserAvatar />}
+			>
+				<Card>
+					<CardHeader>
+						<CardTitle>Invalid event</CardTitle>
+						<CardDescription>
+							The attendee roster could not be loaded.
+						</CardDescription>
+					</CardHeader>
+				</Card>
+			</AppShell>
+		);
+	}
+
+	const attendees = attendeesQuery.data?.items ?? [];
+	const total = attendeesQuery.data?.total ?? 0;
+	const limit = attendeesQuery.data?.limit ?? pageSize;
+	const totalPages = Math.max(1, Math.ceil(total / limit));
+	const eventTitle = eventQuery.data?.title ?? "Event";
+
+	const handleCheckIn = (attendee: AttendeeListItem) => {
+		const payload: UpdateAttendeeStatusInput = {
+			attendeeId: attendee.id,
+			status: "checked_in",
+		};
+		updateStatusMutation.mutate(payload);
+	};
+
+	const handleResetCheckIn = (attendee: AttendeeListItem) => {
+		const payload: UpdateAttendeeStatusInput = {
+			attendeeId: attendee.id,
+			status: "registered",
+			noShow: attendee.noShow,
+		};
+		updateStatusMutation.mutate(payload);
+	};
+
+	const handleMarkNoShow = (attendee: AttendeeListItem) => {
+		const nextStatus =
+			attendee.status === "checked_in" ? "registered" : attendee.status;
+		const payload: UpdateAttendeeStatusInput = {
+			attendeeId: attendee.id,
+			status: nextStatus,
+			noShow: true,
+		};
+		updateStatusMutation.mutate(payload);
+	};
+
+	const handleClearNoShow = (attendee: AttendeeListItem) => {
+		const payload: UpdateAttendeeStatusInput = {
+			attendeeId: attendee.id,
+			status: attendee.status,
+			noShow: false,
+		};
+		updateStatusMutation.mutate(payload);
+	};
+
+	const handleExport = () => {
+		if (!exportParams) return;
+		exportMutation.mutate(exportParams);
+	};
+
+	const handleSendAnnouncement = () => {
+		if (!announcementSubject.trim() || !announcementMessage.trim()) {
+			toast.error("Provide a subject and message before sending");
+			return;
+		}
+		announcementMutation.mutate({
+			eventId,
+			subject: announcementSubject.trim(),
+			message: announcementMessage.trim(),
+			audience: announcementAudience,
+		});
+	};
+
+	const isUpdatingAttendee = (id: string) =>
+		updateStatusMutation.isPending &&
+		updateStatusMutation.variables?.attendeeId === id;
+
+	return (
+		<AppShell
+			breadcrumbs={[
+				{ label: "Admin", href: "/admin/overview" },
+				{ label: "Events", href: "/admin/events" },
+				{ label: eventTitle, href: `/admin/events?highlight=${eventId}` },
+				{ label: "Attendees", current: true },
+			]}
+			headerRight={<UserAvatar />}
+		>
+			<RedirectToSignIn />
+			<div className="flex flex-col gap-4">
+				<div className="flex flex-wrap items-center justify-between gap-3">
+					<div>
+						<h1 className="font-semibold text-2xl">{eventTitle} attendees</h1>
+						<p className="text-muted-foreground text-sm">
+							Monitor registrations, manage check-ins, and reach out to your
+							guests.
+						</p>
+					</div>
+					<div className="flex flex-wrap items-center gap-2">
+						<Button
+							variant="outline"
+							onClick={() => setAnnouncementOpen(true)}
+							disabled={announcementMutation.isPending}
+						>
+							Send announcement
+						</Button>
+						<Button
+							variant="secondary"
+							onClick={handleExport}
+							disabled={exportMutation.isPending || !exportParams}
+						>
+							Export CSV
+						</Button>
+					</div>
+				</div>
+
+				<Card>
+					<CardHeader>
+						<CardTitle>Filters</CardTitle>
+						<CardDescription>Search and segment the roster.</CardDescription>
+					</CardHeader>
+					<CardContent className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+						<div className="flex flex-col gap-2 md:w-64">
+							<Label htmlFor={searchInputId}>Search</Label>
+							<Input
+								id={searchInputId}
+								placeholder="Name, email, or confirmation code"
+								value={search}
+								onChange={(event) => {
+									setSearch(event.target.value);
+									setPage(1);
+								}}
+							/>
+						</div>
+						<div className="flex flex-wrap gap-4">
+							<div className="flex w-48 flex-col gap-2">
+								<Label htmlFor={statusSelectId}>Status</Label>
+								<Select
+									value={statusSegment}
+									onValueChange={(value: StatusSegment) => {
+										setStatusSegment(value);
+										setPage(1);
+									}}
+								>
+									<SelectTrigger id={statusSelectId}>
+										<SelectValue placeholder="All" />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="all">All</SelectItem>
+										<SelectItem value="registered">Registered</SelectItem>
+										<SelectItem value="checked_in">Checked-in</SelectItem>
+										<SelectItem value="waitlisted">Waitlist</SelectItem>
+										<SelectItem value="cancelled">Cancelled</SelectItem>
+									</SelectContent>
+								</Select>
+							</div>
+							<div className="flex w-48 flex-col gap-2">
+								<Label htmlFor={checkInSelectId}>Check-in</Label>
+								<Select
+									value={checkInFilter}
+									onValueChange={(value: CheckInFilter) => {
+										setCheckInFilter(value);
+										setPage(1);
+									}}
+								>
+									<SelectTrigger id={checkInSelectId}>
+										<SelectValue placeholder="All" />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="all">All attendees</SelectItem>
+										<SelectItem value="checked_in">Checked-in</SelectItem>
+										<SelectItem value="not_checked_in">
+											Not checked-in
+										</SelectItem>
+									</SelectContent>
+								</Select>
+							</div>
+							<div className="flex w-48 flex-col gap-2">
+								<Label htmlFor={sortSelectId}>Sort</Label>
+								<Select
+									value={sort}
+									onValueChange={(value) => {
+										setSort(value as AttendeeListInput["sort"]);
+										setPage(1);
+									}}
+								>
+									<SelectTrigger id={sortSelectId}>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="created_desc">Newest first</SelectItem>
+										<SelectItem value="created_asc">Oldest first</SelectItem>
+										<SelectItem value="check_in_desc">
+											Recent check-ins
+										</SelectItem>
+									</SelectContent>
+								</Select>
+							</div>
+							<div className="flex items-center gap-2 pt-6">
+								<Checkbox
+									id={noShowCheckboxId}
+									checked={noShowOnly}
+									onCheckedChange={(value) => {
+										setNoShowOnly(Boolean(value));
+										setPage(1);
+									}}
+								/>
+								<Label htmlFor={noShowCheckboxId} className="text-sm">
+									Show only no-shows
+								</Label>
+							</div>
+						</div>
+					</CardContent>
+				</Card>
+
+				{attendeesQuery.isError ? (
+					<Alert variant="destructive">
+						<AlertTitle>Unable to load attendees</AlertTitle>
+						<AlertDescription>
+							{attendeesQuery.error instanceof Error
+								? attendeesQuery.error.message
+								: "Something went wrong while fetching attendees."}
+						</AlertDescription>
+					</Alert>
+				) : (
+					<Card>
+						<CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+							<div>
+								<CardTitle>Attendee roster</CardTitle>
+								<CardDescription>
+									{total === 0
+										? "No attendees match the current filters."
+										: `Showing ${attendees.length} of ${total} attendee${total === 1 ? "" : "s"}.`}
+								</CardDescription>
+							</div>
+						</CardHeader>
+						<CardContent className="space-y-4">
+							<Table>
+								<TableHeader>
+									<TableRow>
+										<TableHead>Name &amp; contact</TableHead>
+										<TableHead>Ticket</TableHead>
+										<TableHead>Status</TableHead>
+										<TableHead>Check-in</TableHead>
+										<TableHead>No-show</TableHead>
+										<TableHead>Registered</TableHead>
+										<TableHead className="text-right">Actions</TableHead>
+									</TableRow>
+								</TableHeader>
+								<TableBody>
+									{attendeesQuery.isLoading ? (
+										skeletonRowKeys.map((key) => (
+											<TableRow key={key}>
+												<TableCell>
+													<div className="space-y-1">
+														<div className="h-4 w-36 animate-pulse rounded bg-muted" />
+														<div className="h-3 w-48 animate-pulse rounded bg-muted" />
+													</div>
+												</TableCell>
+												<TableCell>
+													<div className="h-4 w-24 animate-pulse rounded bg-muted" />
+												</TableCell>
+												<TableCell>
+													<div className="h-5 w-20 animate-pulse rounded bg-muted" />
+												</TableCell>
+												<TableCell>
+													<div className="h-4 w-28 animate-pulse rounded bg-muted" />
+												</TableCell>
+												<TableCell>
+													<div className="h-4 w-12 animate-pulse rounded bg-muted" />
+												</TableCell>
+												<TableCell>
+													<div className="h-4 w-28 animate-pulse rounded bg-muted" />
+												</TableCell>
+												<TableCell className="text-right">
+													<div className="h-8 w-8 animate-pulse rounded-full bg-muted" />
+												</TableCell>
+											</TableRow>
+										))
+									) : attendees.length === 0 ? (
+										<TableRow>
+											<TableCell
+												colSpan={7}
+												className="text-center text-muted-foreground"
+											>
+												No attendees found for these filters.
+											</TableCell>
+										</TableRow>
+									) : (
+										attendees.map((attendee) => {
+											const isUpdating = isUpdatingAttendee(attendee.id);
+											const checkInText = attendee.checkInAt
+												? formatDistanceToNow(new Date(attendee.checkInAt), {
+														addSuffix: true,
+													})
+												: null;
+											return (
+												<TableRow key={attendee.id}>
+													<TableCell>
+														<div className="flex flex-col">
+															<span className="font-medium text-foreground">
+																{attendee.name ??
+																	attendee.email ??
+																	"Unknown attendee"}
+															</span>
+															{attendee.email ? (
+																<span className="text-muted-foreground text-sm">
+																	{attendee.email}
+																</span>
+															) : null}
+															{attendee.order?.confirmationCode ? (
+																<span className="text-muted-foreground text-xs">
+																	Order #{attendee.order.confirmationCode}
+																</span>
+															) : null}
+														</div>
+													</TableCell>
+													<TableCell>
+														{attendee.ticket?.name ?? "General"}
+													</TableCell>
+													<TableCell>
+														<Badge variant={statusVariants[attendee.status]}>
+															{statusLabels[attendee.status]}
+														</Badge>
+													</TableCell>
+													<TableCell>
+														{attendee.checkInAt ? (
+															<div className="text-sm">
+																<span className="font-medium text-foreground">
+																	Checked-in
+																</span>
+																<p className="text-muted-foreground text-xs">
+																	{checkInText}
+																</p>
+															</div>
+														) : (
+															<span className="text-muted-foreground text-sm">
+																Not yet
+															</span>
+														)}
+													</TableCell>
+													<TableCell>
+														{attendee.noShow ? (
+															<Badge variant="destructive">No-show</Badge>
+														) : (
+															<Badge variant="outline">On track</Badge>
+														)}
+													</TableCell>
+													<TableCell>
+														<span className="text-muted-foreground text-sm">
+															{new Date(attendee.createdAt).toLocaleString()}
+														</span>
+													</TableCell>
+													<TableCell className="text-right">
+														<DropdownMenu>
+															<DropdownMenuTrigger asChild>
+																<Button
+																	variant="ghost"
+																	size="icon"
+																	disabled={isUpdating}
+																>
+																	<MoreHorizontal className="size-4" />
+																</Button>
+															</DropdownMenuTrigger>
+															<DropdownMenuContent align="end">
+																{attendee.status !== "checked_in" ? (
+																	<DropdownMenuItem
+																		onClick={() => handleCheckIn(attendee)}
+																		disabled={isUpdating}
+																	>
+																		Mark checked-in
+																	</DropdownMenuItem>
+																) : (
+																	<DropdownMenuItem
+																		onClick={() => handleResetCheckIn(attendee)}
+																		disabled={isUpdating}
+																	>
+																		Undo check-in
+																	</DropdownMenuItem>
+																)}
+																<DropdownMenuItem
+																	onClick={() =>
+																		attendee.noShow
+																			? handleClearNoShow(attendee)
+																			: handleMarkNoShow(attendee)
+																	}
+																	disabled={isUpdating}
+																>
+																	{attendee.noShow
+																		? "Clear no-show"
+																		: "Mark no-show"}
+																</DropdownMenuItem>
+															</DropdownMenuContent>
+														</DropdownMenu>
+													</TableCell>
+												</TableRow>
+											);
+										})
+									)}
+								</TableBody>
+							</Table>
+							{total > 0 ? (
+								<div className="flex flex-col gap-3 pt-2 sm:flex-row sm:items-center sm:justify-between">
+									<p className="text-muted-foreground text-sm">
+										Page {page} of {totalPages}
+									</p>
+									<Pagination>
+										<PaginationContent>
+											<PaginationItem>
+												<PaginationPrevious
+													href="#"
+													onClick={(event) => {
+														event.preventDefault();
+														setPage((prev) => Math.max(1, prev - 1));
+													}}
+													aria-disabled={page === 1}
+													className={
+														page === 1
+															? "pointer-events-none opacity-50"
+															: undefined
+													}
+												/>
+											</PaginationItem>
+											<PaginationItem>
+												<PaginationLink href="#" isActive>
+													{page}
+												</PaginationLink>
+											</PaginationItem>
+											<PaginationItem>
+												<PaginationNext
+													href="#"
+													onClick={(event) => {
+														event.preventDefault();
+														setPage((prev) => Math.min(totalPages, prev + 1));
+													}}
+													aria-disabled={page >= totalPages}
+													className={
+														page >= totalPages
+															? "pointer-events-none opacity-50"
+															: undefined
+													}
+												/>
+											</PaginationItem>
+										</PaginationContent>
+									</Pagination>
+								</div>
+							) : null}
+						</CardContent>
+					</Card>
+				)}
+			</div>
+
+			<Dialog open={isAnnouncementOpen} onOpenChange={setAnnouncementOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Send announcement</DialogTitle>
+						<DialogDescription>
+							Email registrants with important updates before or during the
+							event.
+						</DialogDescription>
+					</DialogHeader>
+					<div className="space-y-4 py-2">
+						<div className="space-y-2">
+							<Label htmlFor={audienceSelectId}>Audience</Label>
+							<Select
+								value={announcementAudience}
+								onValueChange={(value: BulkAnnouncementInput["audience"]) =>
+									setAnnouncementAudience(value)
+								}
+							>
+								<SelectTrigger id={audienceSelectId}>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="all">All registrants</SelectItem>
+									<SelectItem value="registered">
+										Registered (not checked-in)
+									</SelectItem>
+									<SelectItem value="checked_in">Checked-in only</SelectItem>
+									<SelectItem value="not_checked_in">
+										Not yet checked-in
+									</SelectItem>
+									<SelectItem value="waitlist">Waitlist</SelectItem>
+									<SelectItem value="no_show">Marked no-show</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+						<div className="space-y-2">
+							<Label htmlFor={subjectInputId}>Subject</Label>
+							<Input
+								id={subjectInputId}
+								value={announcementSubject}
+								onChange={(event) => setAnnouncementSubject(event.target.value)}
+							/>
+						</div>
+						<div className="space-y-2">
+							<Label htmlFor={messageTextareaId}>Message</Label>
+							<textarea
+								id={messageTextareaId}
+								className={textareaStyles}
+								value={announcementMessage}
+								onChange={(event) => setAnnouncementMessage(event.target.value)}
+								placeholder="Share schedule changes, arrival details, or onsite reminders."
+							/>
+						</div>
+					</div>
+					<DialogFooter className="gap-2">
+						<Button
+							variant="outline"
+							onClick={() => setAnnouncementOpen(false)}
+							disabled={announcementMutation.isPending}
+						>
+							Cancel
+						</Button>
+						<Button
+							onClick={handleSendAnnouncement}
+							disabled={announcementMutation.isPending}
+						>
+							{announcementMutation.isPending
+								? "Sending…"
+								: "Send announcement"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</AppShell>
+	);
+}

--- a/apps/server/src/components/admin/events/EventAnalyticsSummary.tsx
+++ b/apps/server/src/components/admin/events/EventAnalyticsSummary.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { eventKeys } from "@/lib/query-keys/events";
+import { trpcClient } from "@/lib/trpc-client";
+
+const numberFormatter = new Intl.NumberFormat("en-US");
+
+function formatCurrency(cents: number, currency: string) {
+	const formatter = new Intl.NumberFormat("en-US", {
+		style: "currency",
+		currency: currency.toUpperCase(),
+		maximumFractionDigits: 0,
+	});
+	return formatter.format(cents / 100);
+}
+
+function formatPercent(value: number) {
+	return `${Math.round(value * 100)}%`;
+}
+
+type SparklineProps = {
+	registrations: number[];
+	checkIns: number[];
+};
+
+function Sparkline({ registrations, checkIns }: SparklineProps) {
+	const width = 240;
+	const height = 80;
+	const maxValue = Math.max(
+		1,
+		registrations.reduce((acc, value) => Math.max(acc, value), 0),
+		checkIns.reduce((acc, value) => Math.max(acc, value), 0),
+	);
+	const toPath = (values: number[]) => {
+		if (values.length === 0) return `M0 ${height} L${width} ${height}`;
+		const step = values.length === 1 ? width : width / (values.length - 1);
+		return values
+			.map((value, index) => {
+				const x = index * step;
+				const y = height - (value / maxValue) * height;
+				const sanitizedY = Number.isFinite(y) ? y : height;
+				return `${index === 0 ? "M" : "L"}${x},${sanitizedY}`;
+			})
+			.join(" ");
+	};
+	const registrationPath = toPath(registrations);
+	const checkInPath = toPath(checkIns);
+	return (
+		<svg
+			role="img"
+			aria-label="Registrations versus check-ins sparkline"
+			focusable="false"
+			width={width}
+			height={height}
+			viewBox={`0 0 ${width} ${height}`}
+			className="overflow-visible"
+		>
+			<title>Registrations and check-ins over time</title>
+			<g className="text-primary">
+				<path
+					d={registrationPath}
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={2}
+					strokeLinecap="round"
+					strokeLinejoin="round"
+				/>
+			</g>
+			<g className="text-emerald-500 dark:text-emerald-400">
+				<path
+					d={checkInPath}
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={2}
+					strokeLinecap="round"
+					strokeLinejoin="round"
+				/>
+			</g>
+		</svg>
+	);
+}
+
+type EventAnalyticsSummaryProps = {
+	eventId: string;
+};
+
+export function EventAnalyticsSummary({ eventId }: EventAnalyticsSummaryProps) {
+	const overviewQuery = useQuery({
+		queryKey: eventKeys.analytics.overview(eventId),
+		queryFn: () => trpcClient.events.analytics.overview.query({ eventId }),
+		enabled: Boolean(eventId),
+	});
+	const timeseriesQuery = useQuery({
+		queryKey: eventKeys.analytics.timeseries(eventId, { interval: "day" }),
+		queryFn: () =>
+			trpcClient.events.analytics.timeseries.query({
+				eventId,
+				interval: "day",
+			}),
+		enabled: Boolean(eventId),
+	});
+
+	const registrationsSeries = useMemo(() => {
+		return (
+			timeseriesQuery.data?.points.map((point) => point.registrations) ?? []
+		);
+	}, [timeseriesQuery.data]);
+	const checkInsSeries = useMemo(() => {
+		return timeseriesQuery.data?.points.map((point) => point.checkIns) ?? [];
+	}, [timeseriesQuery.data]);
+
+	if (overviewQuery.isLoading) {
+		return (
+			<div className="grid gap-4 md:grid-cols-3">
+				{[0, 1, 2].map((index) => (
+					<Card key={index}>
+						<CardHeader>
+							<CardTitle>
+								<Skeleton className="h-6 w-32" />
+							</CardTitle>
+							<CardDescription>
+								<Skeleton className="h-4 w-48" />
+							</CardDescription>
+						</CardHeader>
+						<CardContent className="space-y-3">
+							<Skeleton className="h-10 w-24" />
+							<Skeleton className="h-4 w-40" />
+						</CardContent>
+					</Card>
+				))}
+			</div>
+		);
+	}
+
+	if (overviewQuery.isError || !overviewQuery.data) {
+		return (
+			<Card>
+				<CardHeader>
+					<CardTitle>Analytics unavailable</CardTitle>
+					<CardDescription>
+						We couldn’t load the latest metrics for this event. Try again later.
+					</CardDescription>
+				</CardHeader>
+			</Card>
+		);
+	}
+
+	const overview = overviewQuery.data;
+	const revenueCurrency = overview.revenue.currency ?? "usd";
+	const totalRegistrations = overview.totals.registrations;
+	const attendanceRate = overview.attendanceRate;
+	const revenueValue = overview.revenue.cents;
+
+	const totalCheckedIn = overview.totals.checkedIn;
+	const waitlisted = overview.totals.waitlisted;
+	const noShow = overview.totals.noShow;
+	const conversionRate = overview.orders.conversionRate;
+
+	return (
+		<div className="space-y-4">
+			<div className="grid gap-4 md:grid-cols-3">
+				<Card>
+					<CardHeader>
+						<CardTitle>Total registrations</CardTitle>
+						<CardDescription>
+							Includes confirmed and reserved attendees for this event.
+						</CardDescription>
+					</CardHeader>
+					<CardContent className="space-y-2">
+						<div className="font-semibold text-3xl">
+							{numberFormatter.format(totalRegistrations)}
+						</div>
+						<p className="text-muted-foreground text-sm">
+							Checked-in: {numberFormatter.format(totalCheckedIn)} · Waitlist:{" "}
+							{numberFormatter.format(waitlisted)}
+						</p>
+					</CardContent>
+				</Card>
+				<Card>
+					<CardHeader>
+						<CardTitle>Attendance health</CardTitle>
+						<CardDescription>
+							Real-time participation rates from on-site check-ins.
+						</CardDescription>
+					</CardHeader>
+					<CardContent className="space-y-2">
+						<div className="font-semibold text-3xl">
+							{formatPercent(attendanceRate)}
+						</div>
+						<p className="text-muted-foreground text-sm">
+							No-shows recorded: {numberFormatter.format(noShow)}
+						</p>
+					</CardContent>
+				</Card>
+				<Card>
+					<CardHeader>
+						<CardTitle>Revenue &amp; conversion</CardTitle>
+						<CardDescription>
+							Confirmed orders and payment conversion trends.
+						</CardDescription>
+					</CardHeader>
+					<CardContent className="space-y-2">
+						<div className="font-semibold text-3xl">
+							{formatCurrency(revenueValue, revenueCurrency)}
+						</div>
+						<p className="text-muted-foreground text-sm">
+							Conversion rate: {formatPercent(conversionRate)}
+						</p>
+					</CardContent>
+				</Card>
+			</div>
+			<Card>
+				<CardHeader>
+					<CardTitle>Daily momentum</CardTitle>
+					<CardDescription>
+						Registrations (blue) versus check-ins (green) across the last 30
+						days.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+					{timeseriesQuery.isLoading ? (
+						<Skeleton className="h-24 w-full md:w-64" />
+					) : (
+						<Sparkline
+							registrations={registrationsSeries}
+							checkIns={checkInsSeries}
+						/>
+					)}
+					<div className="text-muted-foreground text-sm">
+						<div>
+							Confirmed orders:{" "}
+							{numberFormatter.format(overview.orders.confirmed)}
+						</div>
+						<div>
+							Total orders: {numberFormatter.format(overview.orders.total)}
+						</div>
+					</div>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/apps/server/src/components/admin/events/EventDetailSheet.tsx
+++ b/apps/server/src/components/admin/events/EventDetailSheet.tsx
@@ -1,61 +1,63 @@
 "use client";
 
 import { ShieldCheck } from "lucide-react";
+import Image from "next/image";
 import Link from "next/link";
 import type { EventStatus } from "@/app/(site)/admin/events/event-filters";
 import { statusOptionMap } from "@/app/(site)/admin/events/event-filters";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
-        Sheet,
-        SheetContent,
-        SheetDescription,
-        SheetHeader,
-        SheetTitle,
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetHeader,
+	SheetTitle,
 } from "@/components/ui/sheet";
 import { formatDisplayDate } from "@/lib/datetime";
 import { hasLandingContent } from "@/lib/event-content";
+import { EventAnalyticsSummary } from "./EventAnalyticsSummary";
 import type { StatusAction } from "./status-actions";
 import type { EventListItem } from "./types";
 
 type EventDetailSheetProps = {
-        event: EventListItem | null;
-        statusActions: StatusAction[];
-        onUpdateStatus: (eventId: string, status: EventStatus) => void;
-        onEdit: (event: EventListItem) => void;
-        onClose: () => void;
-        statusLoading: boolean;
-        onDelete: (event: EventListItem) => void;
-        isDeleting: boolean;
+	event: EventListItem | null;
+	statusActions: StatusAction[];
+	onUpdateStatus: (eventId: string, status: EventStatus) => void;
+	onEdit: (event: EventListItem) => void;
+	onClose: () => void;
+	statusLoading: boolean;
+	onDelete: (event: EventListItem) => void;
+	isDeleting: boolean;
 };
 
 export function EventDetailSheet({
-        event,
-        statusActions,
-        onUpdateStatus,
-        onEdit,
-        onClose,
-        statusLoading,
-        onDelete,
-        isDeleting,
+	event,
+	statusActions,
+	onUpdateStatus,
+	onEdit,
+	onClose,
+	statusLoading,
+	onDelete,
+	isDeleting,
 }: EventDetailSheetProps) {
-        const autoApproval = event?.autoApproval ?? null;
-        const autoApprovalReason =
-                autoApproval?.reason.replace(/_/g, " ") ?? "Unknown";
-        const autoApprovalTimestamp = autoApproval?.at
-                ? new Date(autoApproval.at)
-                : null;
-        const publicPath = event ? `/events/${event.slug}` : null;
-        const heroMedia = event?.heroMedia ?? null;
-        const hasHero = Boolean(heroMedia && heroMedia.type && heroMedia.url);
-        const landing = event?.landingPage ?? null;
-        const hasLanding = hasLandingContent(landing);
-        const landingBodyParagraphs =
-                typeof landing?.body === "string" && landing.body.trim().length > 0
-                        ? landing.body.trim().split(/\n{2,}/)
-                        : [];
-        return (
-                <Sheet
+	const autoApproval = event?.autoApproval ?? null;
+	const autoApprovalReason =
+		autoApproval?.reason.replace(/_/g, " ") ?? "Unknown";
+	const autoApprovalTimestamp = autoApproval?.at
+		? new Date(autoApproval.at)
+		: null;
+	const publicPath = event ? `/events/${event.slug}` : null;
+	const heroMedia = event?.heroMedia ?? null;
+	const hasHero = Boolean(heroMedia?.type && heroMedia?.url);
+	const landing = event?.landingPage ?? null;
+	const hasLanding = hasLandingContent(landing);
+	const landingBodyParagraphs =
+		typeof landing?.body === "string" && landing.body.trim().length > 0
+			? landing.body.trim().split(/\n{2,}/)
+			: [];
+	return (
+		<Sheet
 			open={event != null}
 			onOpenChange={(open) => {
 				if (!open) onClose();
@@ -73,6 +75,13 @@ export function EventDetailSheet({
 				</SheetHeader>
 				{event ? (
 					<div className="mt-6 space-y-6">
+						<div className="flex flex-wrap items-center gap-2">
+							<Button asChild size="sm" variant="outline">
+								<Link href={`/admin/events/${event.id}/attendees`}>
+									Open attendee roster
+								</Link>
+							</Button>
+						</div>
 						<div className="space-y-2">
 							<p className="text-muted-foreground text-sm">
 								Event ID: {event.id}
@@ -135,100 +144,118 @@ export function EventDetailSheet({
 								{event.location ?? "No location provided"}
 							</p>
 						</div>
-                                                <div className="space-y-1 text-sm">
-                                                        <p className="font-semibold text-foreground">Provider</p>
-                                                        <p className="text-muted-foreground">
-                                                                {event.provider?.name ?? "Unassigned"}
-                                                        </p>
-                                                        {event.provider?.category ? (
-                                                                <p className="text-muted-foreground">
-                                                                        {event.provider.category}
-                                                                </p>
-                                                        ) : null}
-                                                </div>
-                                                {publicPath ? (
-                                                        <div className="space-y-2 text-sm">
-                                                                <p className="font-semibold text-foreground">Public link</p>
-                                                                <div className="flex flex-wrap items-center gap-2">
-                                                                        <code className="rounded-md bg-muted px-2 py-1 font-mono text-xs">
-                                                                                {publicPath}
-                                                                        </code>
-                                                                        <Button asChild size="sm" variant="outline">
-                                                                                <Link href={publicPath} target="_blank" rel="noopener noreferrer">
-                                                                                        View landing page
-                                                                                </Link>
-                                                                        </Button>
-                                                                </div>
-                                                        </div>
-                                                ) : null}
-                                                {hasHero && heroMedia ? (
-                                                        <div className="space-y-2 text-sm">
-                                                                <p className="font-semibold text-foreground">Hero media</p>
-                                                                <div className="overflow-hidden rounded-md border bg-muted/40">
-                                                                        {heroMedia.type === "video" ? (
-                                                                                <video
-                                                                                        controls
-                                                                                        poster={heroMedia.posterUrl ?? undefined}
-                                                                                        className="h-48 w-full bg-black"
-                                                                                >
-                                                                                        <source src={heroMedia.url ?? ""} />
-                                                                                        Your browser does not support embedded videos.
-                                                                                </video>
-                                                                        ) : (
-                                                                                <img
-                                                                                        src={heroMedia.url ?? ""}
-                                                                                        alt={heroMedia.alt ?? "Event hero media"}
-                                                                                        className="h-48 w-full object-cover"
-                                                                                />
-                                                                        )}
-                                                                </div>
-                                                                <p className="text-muted-foreground text-xs">
-                                                                        {[heroMedia.type ? `Type: ${heroMedia.type}` : null,
-                                                                        heroMedia.alt ? `Alt: ${heroMedia.alt}` : null,
-                                                                        heroMedia.posterUrl ? `Poster: ${heroMedia.posterUrl}` : null]
-                                                                                .filter((value): value is string => Boolean(value))
-                                                                                .join(" • ")}
-                                                                </p>
-                                                        </div>
-                                                ) : null}
-                                                {hasLanding && landing ? (
-                                                        <div className="space-y-2 text-sm">
-                                                                <p className="font-semibold text-foreground">Landing page content</p>
-                                                                {landing.headline ? (
-                                                                        <p className="text-foreground text-base font-medium">
-                                                                                {landing.headline}
-                                                                        </p>
-                                                                ) : null}
-                                                                {landing.subheadline ? (
-                                                                        <p className="text-muted-foreground">{landing.subheadline}</p>
-                                                                ) : null}
-                                                                {landingBodyParagraphs.length > 0 ? (
-                                                                        <div className="space-y-2 text-muted-foreground">
-                                                                                {landingBodyParagraphs.map((paragraph, index) => (
-                                                                                        <p key={index} className="whitespace-pre-wrap leading-relaxed">
-                                                                                                {paragraph}
-                                                                                        </p>
-                                                                                ))}
-                                                                        </div>
-                                                                ) : null}
-                                                                {landing.seoDescription ? (
-                                                                        <p className="text-muted-foreground text-xs">
-                                                                                SEO description: {landing.seoDescription}
-                                                                        </p>
-                                                                ) : null}
-                                                                {landing.cta ? (
-                                                                        <p className="text-muted-foreground text-xs">
-                                                                                CTA: {landing.cta.label ?? ""}
-                                                                                {landing.cta.href ? ` • ${landing.cta.href}` : ""}
-                                                                        </p>
-                                                                ) : null}
-                                                        </div>
-                                                ) : null}
-                                                {event.description ? (
-                                                        <div className="space-y-1 text-sm">
-                                                                <p className="font-semibold text-foreground">Description</p>
-                                                                <p className="whitespace-pre-wrap text-muted-foreground">
-                                                                        {event.description}
+						<div className="space-y-1 text-sm">
+							<p className="font-semibold text-foreground">Provider</p>
+							<p className="text-muted-foreground">
+								{event.provider?.name ?? "Unassigned"}
+							</p>
+							{event.provider?.category ? (
+								<p className="text-muted-foreground">
+									{event.provider.category}
+								</p>
+							) : null}
+						</div>
+						<EventAnalyticsSummary eventId={event.id} />
+						{publicPath ? (
+							<div className="space-y-2 text-sm">
+								<p className="font-semibold text-foreground">Public link</p>
+								<div className="flex flex-wrap items-center gap-2">
+									<code className="rounded-md bg-muted px-2 py-1 font-mono text-xs">
+										{publicPath}
+									</code>
+									<Button asChild size="sm" variant="outline">
+										<Link
+											href={publicPath}
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											View landing page
+										</Link>
+									</Button>
+								</div>
+							</div>
+						) : null}
+						{hasHero && heroMedia ? (
+							<div className="space-y-2 text-sm">
+								<p className="font-semibold text-foreground">Hero media</p>
+								<div className="overflow-hidden rounded-md border bg-muted/40">
+									{heroMedia.type === "video" ? (
+										// biome-ignore lint/a11y/useMediaCaption: Caption tracks are unavailable for synchronized provider media
+										<video
+											controls
+											poster={heroMedia.posterUrl ?? undefined}
+											className="h-48 w-full bg-black"
+										>
+											<source src={heroMedia.url ?? ""} />
+											Your browser does not support embedded videos.
+										</video>
+									) : (
+										<Image
+											src={heroMedia.url ?? ""}
+											alt={heroMedia.alt ?? "Event hero media"}
+											width={768}
+											height={320}
+											unoptimized
+											className="h-48 w-full object-cover"
+										/>
+									)}
+								</div>
+								<p className="text-muted-foreground text-xs">
+									{[
+										heroMedia.type ? `Type: ${heroMedia.type}` : null,
+										heroMedia.alt ? `Alt: ${heroMedia.alt}` : null,
+										heroMedia.posterUrl
+											? `Poster: ${heroMedia.posterUrl}`
+											: null,
+									]
+										.filter((value): value is string => Boolean(value))
+										.join(" • ")}
+								</p>
+							</div>
+						) : null}
+						{hasLanding && landing ? (
+							<div className="space-y-2 text-sm">
+								<p className="font-semibold text-foreground">
+									Landing page content
+								</p>
+								{landing.headline ? (
+									<p className="font-medium text-base text-foreground">
+										{landing.headline}
+									</p>
+								) : null}
+								{landing.subheadline ? (
+									<p className="text-muted-foreground">{landing.subheadline}</p>
+								) : null}
+								{landingBodyParagraphs.length > 0 ? (
+									<div className="space-y-2 text-muted-foreground">
+										{landingBodyParagraphs.map((paragraph, index) => (
+											<p
+												key={`${index}-${paragraph.slice(0, 16)}`}
+												className="whitespace-pre-wrap leading-relaxed"
+											>
+												{paragraph}
+											</p>
+										))}
+									</div>
+								) : null}
+								{landing.seoDescription ? (
+									<p className="text-muted-foreground text-xs">
+										SEO description: {landing.seoDescription}
+									</p>
+								) : null}
+								{landing.cta ? (
+									<p className="text-muted-foreground text-xs">
+										CTA: {landing.cta.label ?? ""}
+										{landing.cta.href ? ` • ${landing.cta.href}` : ""}
+									</p>
+								) : null}
+							</div>
+						) : null}
+						{event.description ? (
+							<div className="space-y-1 text-sm">
+								<p className="font-semibold text-foreground">Description</p>
+								<p className="whitespace-pre-wrap text-muted-foreground">
+									{event.description}
 								</p>
 							</div>
 						) : null}
@@ -238,28 +265,28 @@ export function EventDetailSheet({
 								{JSON.stringify(event.metadata ?? {}, null, 2)}
 							</pre>
 						</div>
-                                                <div className="flex flex-wrap gap-2">
-                                                        {statusActions.map((action) => (
-                                                                <Button
-                                                                        key={action.status}
-                                                                        onClick={() => onUpdateStatus(event.id, action.status)}
-                                                                        disabled={statusLoading}
-                                                                >
-                                                                        <action.icon className="mr-2 size-4" />
-                                                                        {action.label}
-                                                                </Button>
-                                                        ))}
-                                                        <Button variant="outline" onClick={() => onEdit(event)}>
-                                                                Edit event
-                                                        </Button>
-                                                        <Button
-                                                                variant="destructive"
-                                                                onClick={() => onDelete(event)}
-                                                                disabled={isDeleting}
-                                                        >
-                                                                {isDeleting ? "Deleting…" : "Delete event"}
-                                                        </Button>
-                                                </div>
+						<div className="flex flex-wrap gap-2">
+							{statusActions.map((action) => (
+								<Button
+									key={action.status}
+									onClick={() => onUpdateStatus(event.id, action.status)}
+									disabled={statusLoading}
+								>
+									<action.icon className="mr-2 size-4" />
+									{action.label}
+								</Button>
+							))}
+							<Button variant="outline" onClick={() => onEdit(event)}>
+								Edit event
+							</Button>
+							<Button
+								variant="destructive"
+								onClick={() => onDelete(event)}
+								disabled={isDeleting}
+							>
+								{isDeleting ? "Deleting…" : "Delete event"}
+							</Button>
+						</div>
 					</div>
 				) : null}
 			</SheetContent>

--- a/apps/server/src/db/migrations/0004_event_attendee_engagement.sql
+++ b/apps/server/src/db/migrations/0004_event_attendee_engagement.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "event_attendee"
+        ADD COLUMN "no_show" boolean NOT NULL DEFAULT false;
+
+ALTER TYPE "event_email_type" ADD VALUE IF NOT EXISTS 'announcement';

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
 			"when": 1759413129284,
 			"tag": "0003_event_email_delivery",
 			"breakpoints": false
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1759746442351,
+			"tag": "0004_event_attendee_engagement",
+			"breakpoints": false
 		}
 	]
 }

--- a/apps/server/src/db/schema/app.ts
+++ b/apps/server/src/db/schema/app.ts
@@ -72,6 +72,7 @@ export const eventEmailType = pgEnum("event_email_type", [
 	"update",
 	"cancellation",
 	"follow_up",
+	"announcement",
 ]);
 
 export const eventEmailStatus = pgEnum("event_email_status", [
@@ -402,6 +403,7 @@ export const attendee = pgTable(
 		status: attendeeStatus("status").notNull().default("reserved"),
 		confirmationCode: text("confirmation_code").notNull(),
 		checkInAt: timestamp("check_in_at", { withTimezone: true }),
+		noShow: boolean("no_show").notNull().default(false),
 		metadata: jsonb("metadata")
 			.$type<Record<string, unknown>>()
 			.notNull()

--- a/apps/server/src/lib/query-keys/events.ts
+++ b/apps/server/src/lib/query-keys/events.ts
@@ -1,5 +1,29 @@
+const serialize = (value: unknown) => JSON.stringify(value);
+
 export const eventKeys = {
 	all: ["events"] as const,
 	recentForUser: (params?: { limit?: number }) =>
 		[...eventKeys.all, "recentForUser", params?.limit ?? null] as const,
+	attendees: {
+		root: (eventId: string) =>
+			[...eventKeys.all, "attendees", eventId] as const,
+		list: (eventId: string, params: Record<string, unknown>) =>
+			[
+				...eventKeys.attendees.root(eventId),
+				"list",
+				serialize(params),
+			] as const,
+	},
+	analytics: {
+		root: (eventId: string) =>
+			[...eventKeys.all, "analytics", eventId] as const,
+		overview: (eventId: string) =>
+			[...eventKeys.analytics.root(eventId), "overview"] as const,
+		timeseries: (eventId: string, params: Record<string, unknown>) =>
+			[
+				...eventKeys.analytics.root(eventId),
+				"timeseries",
+				serialize(params),
+			] as const,
+	},
 };


### PR DESCRIPTION
## Summary
- add the admin event attendee roster with pagination, filtering, CSV exports, and announcement workflows
- surface analytics and metrics inside the admin event detail sheet with supporting backend routes and schema changes
- extend mailer scheduling, query keys, and database models for no-show tracking and bulk announcements while tightening unique constraint handling

## Testing
- npx biome check 'apps/server/src/app/(site)/admin/events/[id]/attendees/page.tsx' apps/server/src/components/admin/events/EventAnalyticsSummary.tsx apps/server/src/components/admin/events/EventDetailSheet.tsx apps/server/src/lib/query-keys/events.ts apps/server/src/lib/mailer/scheduler.ts apps/server/src/routers/events.ts apps/server/src/db/schema/app.ts


------
https://chatgpt.com/codex/tasks/task_b_68e39847c3b4832797e9f3f0832193d4