### PR TITLE
feat: enforce TUKI SSO roles and flow

### DIFF
--- a/apps/server/src/app/(site)/auth/[path]/page.tsx
+++ b/apps/server/src/app/(site)/auth/[path]/page.tsx
@@ -1,6 +1,7 @@
 import { AuthView } from "@daveyplate/better-auth-ui";
 import { authViewPaths } from "@daveyplate/better-auth-ui/server";
 import Link from "next/link";
+
 import { SSOAuth } from "@/components/SSOAuth";
 
 export const dynamicParams = false;
@@ -9,12 +10,89 @@ export function generateStaticParams() {
 	return Object.values(authViewPaths).map((path) => ({ path }));
 }
 
+const ssoCopy = new Map<string, { title: string; description: string }>([
+	[
+		authViewPaths.SIGN_IN,
+		{
+			title: "Sign in with TUKI",
+			description:
+				"CalendarSync now requires TUKI single sign-on. Continue with your organization credentials to access the dashboard.",
+		},
+	],
+	[
+		authViewPaths.SIGN_UP,
+		{
+			title: "Create your CalendarSync account",
+			description:
+				"New accounts are provisioned through TUKI. Use the button below to complete enrollment with your workspace administrator.",
+		},
+	],
+	[
+		authViewPaths.FORGOT_PASSWORD,
+		{
+			title: "Password resets disabled",
+			description:
+				"Password-based access has been replaced with TUKI single sign-on. Return to your sign-in flow below.",
+		},
+	],
+	[
+		authViewPaths.RESET_PASSWORD,
+		{
+			title: "Use TUKI to manage access",
+			description:
+				"CalendarSync no longer manages passwords directly. Authenticate through TUKI to regain access to your account.",
+		},
+	],
+	[
+		authViewPaths.RECOVER_ACCOUNT,
+		{
+			title: "Recover access with TUKI",
+			description:
+				"Account recovery is handled by your TUKI identity provider. Continue with single sign-on to get started.",
+		},
+	],
+	[
+		authViewPaths.EMAIL_OTP,
+		{
+			title: "Magic links unavailable",
+			description:
+				"Email-based login has been disabled. Use TUKI single sign-on for secure access to CalendarSync.",
+		},
+	],
+	[
+		authViewPaths.MAGIC_LINK,
+		{
+			title: "Use TUKI single sign-on",
+			description:
+				"We now rely exclusively on TUKI SSO. Launch the sign-in flow below to continue.",
+		},
+	],
+]);
+
 export default async function AuthPage({
 	params,
 }: {
 	params: Promise<{ path: string }>;
 }) {
 	const { path } = await params;
+
+	if (ssoCopy.has(path)) {
+		const copy = ssoCopy.get(path)!;
+		return (
+			<main className="hero-gradient container flex grow flex-col items-center justify-center self-center p-4 md:p-6">
+				<div className="w-full max-w-md space-y-6 rounded-xl border bg-background p-6 text-center shadow-lg">
+					<Link className="block font-bold text-2xl" href="/">
+						CalendarSync
+					</Link>
+					<div className="space-y-3">
+						<h1 className="font-semibold text-xl">{copy.title}</h1>
+						<p className="text-muted-foreground text-sm">{copy.description}</p>
+						<SSOAuth />
+					</div>
+				</div>
+			</main>
+		);
+	}
 
 	return (
 		<main className="hero-gradient container flex grow flex-col items-center justify-center self-center p-4 md:p-6">

--- a/apps/server/src/components/SSOAuth.tsx
+++ b/apps/server/src/components/SSOAuth.tsx
@@ -1,31 +1,69 @@
 "use client";
-import { usePathname } from "next/navigation";
+
 import React from "react";
+
 import { authClient } from "@/lib/auth-client";
+
+import { Alert, AlertDescription, AlertTitle } from "./ui/alert";
 import { Button } from "./ui/button";
-import { Separator } from "./ui/separator";
+
+const providerId = process.env.NEXT_PUBLIC_OIDC_PROVIDER_ID?.trim();
 
 export const SSOAuth = () => {
-	const pathname = usePathname();
-	const showSso = pathname === "/auth/sign-in" || pathname === "/auth/sign-up";
-	if (!showSso) {
-		return null;
-	}
+	const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+	const [isLoading, setIsLoading] = React.useState(false);
+	const isConfigured = Boolean(providerId);
+
+	const handleSignIn = React.useCallback(async () => {
+		if (!isConfigured || !providerId) {
+			setErrorMessage(
+				"Single sign-on is not fully configured. Contact an administrator to enable TUKI sign-in.",
+			);
+			return;
+		}
+
+		setErrorMessage(null);
+		setIsLoading(true);
+		try {
+			const { error } = await authClient.signIn.oauth2({
+				providerId,
+				callbackURL: "/",
+			});
+			if (error) {
+				setErrorMessage(
+					error.message || "Unable to start single sign-on. Please try again.",
+				);
+			}
+		} catch (err) {
+			setErrorMessage(
+				err instanceof Error
+					? err.message
+					: "We couldn't start single sign-on. Please try again or reach out to your administrator.",
+			);
+		} finally {
+			setIsLoading(false);
+		}
+	}, [isConfigured, providerId]);
+
 	return (
 		<div className="space-y-4">
 			<Button
-				onClick={async () => {
-					const { data, error } = await authClient.signIn.oauth2({
-						providerId: process.env.NEXT_PUBLIC_OIDC_PROVIDER_ID!,
-						callbackURL: "/",
-					});
-				}}
+				onClick={handleSignIn}
 				variant="outline"
-				className="mt-3 w-full"
+				disabled={!isConfigured || isLoading}
+				className="w-full"
 			>
-				Continue with TUKI SSO
+				{isLoading ? "Redirecting to TUKI…" : "Continue with TUKI SSO"}
 			</Button>
-			<Separator />
+			{(!isConfigured || errorMessage) && (
+				<Alert variant="destructive">
+					<AlertTitle>Single sign-on unavailable</AlertTitle>
+					<AlertDescription>
+						{errorMessage ??
+							"Environment variables for the TUKI OAuth client are missing."}
+					</AlertDescription>
+				</Alert>
+			)}
 		</div>
 	);
 };

--- a/apps/server/src/components/admin/RequireAdmin.tsx
+++ b/apps/server/src/components/admin/RequireAdmin.tsx
@@ -6,6 +6,7 @@ import * as React from "react";
 import { toast } from "sonner";
 
 import { authClient } from "@/lib/auth-client";
+import { getUserRoles } from "@/lib/session";
 
 export function RequireAdmin({ children }: { children: React.ReactNode }) {
 	const router = useRouter();
@@ -22,12 +23,7 @@ export function RequireAdmin({ children }: { children: React.ReactNode }) {
 			return;
 		}
 
-		const userRole = (
-			session.user as typeof session.user & {
-				role?: string | null;
-			}
-		)?.role;
-		const roles = userRole ? [userRole] : [];
+		const roles = getUserRoles(session);
 
 		if (!roles.includes("admin")) {
 			toast.error("Administrator access required");

--- a/apps/server/src/lib/context.ts
+++ b/apps/server/src/lib/context.ts
@@ -1,11 +1,12 @@
-import { auth } from "./auth";
+import { auth, enforceTukiSessionRoles } from "./auth";
 
 export async function createContext(req: Request) {
 	const session = await auth.api.getSession({
 		headers: req.headers,
 	});
+	const normalized = await enforceTukiSessionRoles(session);
 	return {
-		session,
+		session: normalized.session,
 	};
 }
 

--- a/apps/server/src/lib/trpc.ts
+++ b/apps/server/src/lib/trpc.ts
@@ -1,5 +1,7 @@
 import { initTRPC, TRPCError } from "@trpc/server";
+
 import type { Context } from "./context";
+import { getUserRoles } from "./session";
 
 const t = initTRPC.context<Context>().create();
 
@@ -24,12 +26,7 @@ export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
 });
 
 export const adminProcedure = protectedProcedure.use(({ ctx, next }) => {
-	const userRole = (
-		ctx.session.user as typeof ctx.session.user & {
-			role?: string | null;
-		}
-	)?.role;
-	const roles = userRole ? [userRole] : [];
+	const roles = getUserRoles(ctx.session);
 
 	if (!roles.includes("admin")) {
 		throw new TRPCError({

--- a/apps/server/src/lib/tuki.ts
+++ b/apps/server/src/lib/tuki.ts
@@ -1,0 +1,392 @@
+import { and, desc, eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import { account } from "@/db/schema/auth";
+
+import type { SessionLike } from "./session";
+
+const ROLE_KEY_SET = new Set([
+	"https://tuki.app/roles",
+	"https://tuki.app/claims/roles",
+	"tuki_roles",
+	"tukiroles",
+]);
+
+const TIER_KEY_SET = new Set([
+	"https://tuki.app/tier",
+	"https://tuki.app/claims/tier",
+	"tuki_tier",
+	"tukitier",
+	"tier",
+]);
+
+const ORGANIZATION_KEY_SET = new Set([
+	"https://tuki.app/organizations",
+	"https://tuki.app/claims/organizations",
+	"tuki_organizations",
+	"tukiorganizations",
+	"organizations",
+	"organization",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function toOptionalString(value: unknown): string | null {
+	if (typeof value === "string") {
+		const trimmed = value.trim();
+		return trimmed.length > 0 ? trimmed : null;
+	}
+
+	if (typeof value === "number" || typeof value === "boolean") {
+		return String(value);
+	}
+
+	return null;
+}
+
+function toStringArray(value: unknown): string[] {
+	if (Array.isArray(value)) {
+		return value
+			.flatMap((item) => toStringArray(item))
+			.map((item) => item.trim())
+			.filter((item) => item.length > 0);
+	}
+
+	const asString = toOptionalString(value);
+	if (asString) {
+		return [asString];
+	}
+
+	if (isRecord(value)) {
+		const collected: string[] = [];
+		for (const nested of Object.values(value)) {
+			collected.push(...toStringArray(nested));
+		}
+		return collected;
+	}
+
+	return [];
+}
+
+function toOrganizationArray(value: unknown): string[] {
+	if (Array.isArray(value)) {
+		return value
+			.flatMap((item) => toOrganizationArray(item))
+			.filter(
+				(item): item is string => typeof item === "string" && item.length > 0,
+			);
+	}
+
+	if (isRecord(value)) {
+		const slug = toOptionalString(value.slug);
+		const id = toOptionalString(value.id);
+		const name = toOptionalString(value.name);
+
+		const identifiers = [slug, id, name].filter(
+			(identifier): identifier is string =>
+				typeof identifier === "string" && identifier.length > 0,
+		);
+
+		if (identifiers.length > 0) {
+			return identifiers;
+		}
+
+		const collected: string[] = [];
+		for (const nested of Object.values(value)) {
+			collected.push(...toOrganizationArray(nested));
+		}
+		return collected;
+	}
+
+	const asString = toOptionalString(value);
+	return asString ? [asString] : [];
+}
+
+function shouldInspectKey(key: string): boolean {
+	return (
+		key.includes("metadata") ||
+		key.includes("claims") ||
+		key.includes("tuki") ||
+		key.includes("app")
+	);
+}
+
+function isRoleKey(key: string): boolean {
+	if (ROLE_KEY_SET.has(key)) return true;
+	return key.includes("tuki") && key.includes("role");
+}
+
+function isTierKey(key: string): boolean {
+	if (TIER_KEY_SET.has(key)) return true;
+	return key.includes("tuki") && key.includes("tier");
+}
+
+function isOrganizationKey(key: string): boolean {
+	if (ORGANIZATION_KEY_SET.has(key)) return true;
+	return key.includes("tuki") && (key.includes("org") || key.includes("team"));
+}
+
+export type TukiClaims = {
+	roles: string[];
+	tier: string | null;
+	organizations: string[];
+};
+
+export function extractTukiClaims(
+	source: Record<string, unknown> | null | undefined,
+): TukiClaims {
+	const roles = new Set<string>();
+	const organizations = new Set<string>();
+	let tier: string | null = null;
+
+	if (!source || typeof source !== "object") {
+		return { roles: [], tier: null, organizations: [] };
+	}
+
+	const stack: Record<string, unknown>[] = [source];
+
+	while (stack.length > 0) {
+		const current = stack.pop();
+		if (!current) continue;
+
+		for (const [rawKey, value] of Object.entries(current)) {
+			const key = rawKey.toLowerCase();
+
+			if (isRoleKey(key)) {
+				for (const role of toStringArray(value)) {
+					if (role) {
+						roles.add(role);
+					}
+				}
+				continue;
+			}
+
+			if (isTierKey(key) && tier === null) {
+				tier = toOptionalString(value);
+				if (tier) {
+					tier = tier;
+				}
+			}
+
+			if (isOrganizationKey(key)) {
+				for (const identifier of toOrganizationArray(value)) {
+					if (identifier) {
+						organizations.add(identifier);
+					}
+				}
+			}
+
+			if (Array.isArray(value)) {
+				for (const item of value) {
+					if (isRecord(item)) {
+						stack.push(item);
+					}
+				}
+				continue;
+			}
+
+			if (isRecord(value) && shouldInspectKey(key)) {
+				stack.push(value);
+			}
+		}
+	}
+
+	return {
+		roles: Array.from(roles),
+		tier,
+		organizations: Array.from(organizations),
+	};
+}
+
+function normalizeRoleValue(value: string): string {
+	return value.trim().toLowerCase();
+}
+
+function normalizeRoleSegment(value: string): string {
+	return value
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+}
+
+export type DerivedRolesResult = {
+	roles: string[];
+	derivedCount: number;
+};
+
+export function buildRoleSet(
+	baseRoles: Iterable<string>,
+	claims: TukiClaims,
+): DerivedRolesResult {
+	const normalized = new Set<string>();
+	let derivedCount = 0;
+
+	for (const role of baseRoles) {
+		const normalizedRole = normalizeRoleValue(role);
+		if (normalizedRole.length > 0) {
+			normalized.add(normalizedRole);
+		}
+	}
+
+	for (const role of claims.roles) {
+		const normalizedRole = normalizeRoleValue(role);
+		if (normalizedRole.length > 0 && !normalized.has(normalizedRole)) {
+			normalized.add(normalizedRole);
+			derivedCount++;
+		}
+	}
+
+	if (claims.tier) {
+		const tierRole = `tier:${normalizeRoleSegment(claims.tier)}`;
+		if (tierRole.length > 5 && !normalized.has(tierRole)) {
+			normalized.add(tierRole);
+			derivedCount++;
+		}
+	}
+
+	for (const organization of claims.organizations) {
+		const orgRole = `org:${normalizeRoleSegment(organization)}`;
+		if (orgRole.length > 4 && !normalized.has(orgRole)) {
+			normalized.add(orgRole);
+			derivedCount++;
+		}
+	}
+
+	return {
+		roles: Array.from(normalized),
+		derivedCount,
+	};
+}
+
+export function decodeJwtClaims(
+	token: string | null | undefined,
+): Record<string, unknown> | null {
+	if (!token) return null;
+
+	const segments = token.split(".");
+	if (segments.length < 2) return null;
+
+	try {
+		const payload = segments[1];
+		const normalizedPayload = payload.replace(/-/g, "+").replace(/_/g, "/");
+		const paddingLength = normalizedPayload.length % 4;
+		const paddedPayload =
+			paddingLength === 0
+				? normalizedPayload
+				: normalizedPayload.padEnd(
+						normalizedPayload.length + (4 - paddingLength),
+						"=",
+					);
+		const decoded = Buffer.from(paddedPayload, "base64").toString("utf8");
+		const parsed = JSON.parse(decoded) as unknown;
+		if (isRecord(parsed)) {
+			return parsed;
+		}
+	} catch (error) {
+		console.error("Failed to decode JWT payload", error);
+	}
+
+	return null;
+}
+
+export async function loadTukiClaimsFromAccount(
+	userId: string,
+	providerId: string,
+): Promise<TukiClaims | null> {
+	if (!userId || !providerId) return null;
+
+	const [row] = await db
+		.select({
+			idToken: account.idToken,
+			accessToken: account.accessToken,
+			scope: account.scope,
+		})
+		.from(account)
+		.where(and(eq(account.userId, userId), eq(account.providerId, providerId)))
+		.orderBy(desc(account.updatedAt))
+		.limit(1);
+
+	const claimsSource = decodeJwtClaims(row?.idToken ?? null);
+	if (!claimsSource) {
+		return null;
+	}
+
+	return extractTukiClaims(claimsSource);
+}
+
+export async function hydrateSessionWithTukiClaims(
+	session: SessionLike,
+	providerId: string,
+): Promise<
+	| { session: SessionLike; derivedRoles: number }
+	| { session: null; derivedRoles: 0 }
+> {
+	if (!session) {
+		return { session: null, derivedRoles: 0 };
+	}
+
+	const sessionUser =
+		session && typeof session === "object"
+			? (session as { user?: Record<string, unknown> | null }).user
+			: null;
+
+	if (!sessionUser || typeof sessionUser !== "object") {
+		return { session, derivedRoles: 0 };
+	}
+
+	const user = sessionUser as Record<string, unknown> & {
+		id?: string;
+		role?: string | null;
+		roles?: string[] | null;
+	};
+
+	const baseRoles = new Set<string>();
+	if (Array.isArray(user.roles)) {
+		for (const role of user.roles) {
+			if (typeof role === "string" && role.trim().length > 0) {
+				baseRoles.add(role);
+			}
+		}
+	}
+
+	if (typeof user.role === "string" && user.role.trim().length > 0) {
+		baseRoles.add(user.role);
+	}
+
+	let claims = extractTukiClaims(user);
+
+	if (
+		claims.roles.length === 0 &&
+		!claims.tier &&
+		claims.organizations.length === 0 &&
+		user.id
+	) {
+		const fromAccount = await loadTukiClaimsFromAccount(user.id, providerId);
+		if (fromAccount) {
+			claims = {
+				roles: fromAccount.roles.length > 0 ? fromAccount.roles : claims.roles,
+				tier: fromAccount.tier ?? claims.tier,
+				organizations:
+					fromAccount.organizations.length > 0
+						? fromAccount.organizations
+						: claims.organizations,
+			};
+		}
+	}
+
+	const { roles, derivedCount } = buildRoleSet(baseRoles, claims);
+
+	(user as { roles?: string[] }).roles = roles;
+	(user as { tukiTier?: string | null }).tukiTier = claims.tier ?? null;
+	(user as { tukiOrganizations?: string[] }).tukiOrganizations =
+		claims.organizations;
+
+	if (roles.length === 0 || derivedCount === 0) {
+		return { session: null, derivedRoles: 0 };
+	}
+
+	return { session, derivedRoles: derivedCount };
+}


### PR DESCRIPTION
## Summary
- disable local email/password auth in Better Auth and require the configured TUKI OAuth client
- derive TUKI roles, tier, and organization claims for each session and reject sessions without them in TRPC and admin surfaces
- replace password-based auth views with a TUKI SSO-only experience and surface configuration errors in the SSO button

## Testing
- `bun run check` *(fails: existing biome lint violations for legacy CSS/unused parameters)*

------
https://chatgpt.com/codex/tasks/task_b_68e3bf9d5db4832799d6f9b77a6d9f0d