### PR TITLE
feat: queue event automations during approval

### DIFF
--- a/apps/server/src/components/admin/events/EventActionsMenu.tsx
+++ b/apps/server/src/components/admin/events/EventActionsMenu.tsx
@@ -15,54 +15,69 @@ import {
 import type { StatusAction } from "./status-actions";
 
 type EventActionsMenuProps = {
-        statusActions: StatusAction[];
-        onUpdateStatus: (status: StatusAction["status"]) => void;
-        onEdit: () => void;
-        onView: () => void;
-        disabled?: boolean;
-        onDelete: () => void;
-        isDeleting?: boolean;
+	statusActions: StatusAction[];
+	onUpdateStatus: (action: StatusAction) => void;
+	onEdit: () => void;
+	onView: () => void;
+	disabled?: boolean;
+	onDelete: () => void;
+	isDeleting?: boolean;
 };
 
 export function EventActionsMenu({
-        statusActions,
-        onUpdateStatus,
-        onEdit,
-        onView,
-        onDelete,
-        isDeleting = false,
-        disabled = false,
+	statusActions,
+	onUpdateStatus,
+	onEdit,
+	onView,
+	onDelete,
+	isDeleting = false,
+	disabled = false,
 }: EventActionsMenuProps) {
-        return (
-                <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                                <Button variant="ghost" size="icon" disabled={disabled}>
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button variant="ghost" size="icon" disabled={disabled}>
 					<MoreHorizontal className="size-4" />
 				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="end" className="w-48">
 				<DropdownMenuLabel>Moderation</DropdownMenuLabel>
-                                {statusActions.map((action) => (
-                                        <DropdownMenuItem
-                                                key={action.status}
-                                                onClick={() => onUpdateStatus(action.status)}
-                                        >
-                                                <action.icon className="mr-2 size-4" />
-                                                {action.label}
-                                        </DropdownMenuItem>
-                                ))}
-                                <DropdownMenuSeparator />
-                                <DropdownMenuItem onClick={onEdit}>Edit event</DropdownMenuItem>
-                                <DropdownMenuItem onClick={onView}>View details</DropdownMenuItem>
-                                <DropdownMenuSeparator />
-                                <DropdownMenuItem
-                                        onClick={onDelete}
-                                        disabled={isDeleting}
-                                        className="text-destructive focus:text-destructive"
-                                >
-                                        Delete event
-                                </DropdownMenuItem>
-                        </DropdownMenuContent>
-                </DropdownMenu>
-        );
+				{statusActions.map((action) => (
+					<DropdownMenuItem
+						key={`${action.status}-${
+							action.publish === undefined
+								? "auto"
+								: action.publish
+									? "publish"
+									: "draft"
+						}`}
+						onClick={() => onUpdateStatus(action)}
+					>
+						<div className="flex w-full items-start gap-2">
+							<action.icon className="mt-0.5 size-4 shrink-0" />
+							<div className="flex flex-col">
+								<span>{action.label}</span>
+								{action.description ? (
+									<span className="text-muted-foreground text-xs">
+										{action.description}
+									</span>
+								) : null}
+							</div>
+						</div>
+					</DropdownMenuItem>
+				))}
+				<DropdownMenuSeparator />
+				<DropdownMenuItem onClick={onEdit}>Edit event</DropdownMenuItem>
+				<DropdownMenuItem onClick={onView}>View details</DropdownMenuItem>
+				<DropdownMenuSeparator />
+				<DropdownMenuItem
+					onClick={onDelete}
+					disabled={isDeleting}
+					className="text-destructive focus:text-destructive"
+				>
+					Delete event
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
 }

--- a/apps/server/src/components/admin/events/EventDetailSheet.tsx
+++ b/apps/server/src/components/admin/events/EventDetailSheet.tsx
@@ -3,6 +3,7 @@
 import { ShieldCheck } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import type { ComponentProps } from "react";
 import type { EventStatus } from "@/app/(site)/admin/events/event-filters";
 import { statusOptionMap } from "@/app/(site)/admin/events/event-filters";
 import { Badge } from "@/components/ui/badge";
@@ -19,6 +20,27 @@ import { hasLandingContent } from "@/lib/event-content";
 import { EventAnalyticsSummary } from "./EventAnalyticsSummary";
 import type { StatusAction } from "./status-actions";
 import type { EventListItem } from "./types";
+
+type VisibilityBadge = {
+	label: string;
+	variant: ComponentProps<typeof Badge>["variant"];
+};
+
+function resolveVisibility(
+	event: EventListItem | null,
+): VisibilityBadge | null {
+	if (!event) return null;
+	if (event.status === "approved" && event.isPublished) {
+		return { label: "Published", variant: "default" };
+	}
+	if (event.status === "approved") {
+		return { label: "Approved draft", variant: "secondary" };
+	}
+	if (event.status === "pending") {
+		return { label: "Pending review", variant: "outline" };
+	}
+	return { label: "Archived", variant: "outline" };
+}
 
 type EventDetailSheetProps = {
 	event: EventListItem | null;
@@ -56,6 +78,7 @@ export function EventDetailSheet({
 		typeof landing?.body === "string" && landing.body.trim().length > 0
 			? landing.body.trim().split(/\n{2,}/)
 			: [];
+	const visibility = resolveVisibility(event);
 	return (
 		<Sheet
 			open={event != null}
@@ -95,9 +118,9 @@ export function EventDetailSheet({
 								<Badge variant={statusOptionMap[event.status].badgeVariant}>
 									{statusOptionMap[event.status].label}
 								</Badge>
-								<Badge variant={event.isPublished ? "default" : "outline"}>
-									{event.isPublished ? "Published" : "Draft"}
-								</Badge>
+								{visibility ? (
+									<Badge variant={visibility.variant}>{visibility.label}</Badge>
+								) : null}
 								{event.isAllDay ? (
 									<Badge variant="outline">All-day</Badge>
 								) : null}

--- a/apps/server/src/components/admin/events/status-actions.ts
+++ b/apps/server/src/components/admin/events/status-actions.ts
@@ -1,4 +1,4 @@
-import { RefreshCcw, UserCheck, UserX } from "lucide-react";
+import { FileCheck, RefreshCcw, UserCheck, UserX } from "lucide-react";
 import type { ComponentType, SVGProps } from "react";
 
 import type { EventStatus } from "@/app/(site)/admin/events/event-filters";
@@ -7,10 +7,30 @@ export type StatusAction = {
 	label: string;
 	status: EventStatus;
 	icon: ComponentType<SVGProps<SVGSVGElement>>;
+	publish?: boolean;
+	description?: string;
 };
 
 export const statusActions: StatusAction[] = [
-	{ label: "Validate", status: "approved", icon: UserCheck },
-	{ label: "Mark pending", status: "pending", icon: RefreshCcw },
-	{ label: "Archive", status: "rejected", icon: UserX },
+	{
+		label: "Approve & publish",
+		status: "approved",
+		publish: true,
+		icon: UserCheck,
+		description: "Queues sync + digest jobs for downstream channels.",
+	},
+	{
+		label: "Approve (keep draft)",
+		status: "approved",
+		publish: false,
+		icon: FileCheck,
+		description: "Approve while leaving the event unpublished.",
+	},
+	{
+		label: "Mark pending",
+		status: "pending",
+		icon: RefreshCcw,
+		publish: false,
+	},
+	{ label: "Archive", status: "rejected", icon: UserX, publish: false },
 ];

--- a/apps/server/src/db/migrations/0005_event_automation_jobs.sql
+++ b/apps/server/src/db/migrations/0005_event_automation_jobs.sql
@@ -1,0 +1,17 @@
+CREATE TYPE "public"."event_automation_type" AS ENUM('calendar_sync', 'digest_refresh');--> statement-breakpoint
+CREATE TYPE "public"."event_automation_status" AS ENUM('pending', 'processing', 'completed', 'failed');--> statement-breakpoint
+CREATE TABLE "event_automation_job" (
+        "id" text PRIMARY KEY NOT NULL,
+        "event_id" text NOT NULL,
+        "type" "event_automation_type" NOT NULL,
+        "status" "event_automation_status" DEFAULT 'pending' NOT NULL,
+        "payload" jsonb DEFAULT '{}'::jsonb NOT NULL,
+        "attempts" integer DEFAULT 0 NOT NULL,
+        "last_error" text,
+        "scheduled_at" timestamp with time zone DEFAULT now() NOT NULL,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+        "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);--> statement-breakpoint
+CREATE UNIQUE INDEX "event_automation_job_event_id_type_status_unique" ON "event_automation_job" USING btree ("event_id", "type", "status");--> statement-breakpoint
+CREATE INDEX "event_automation_job_event_idx" ON "event_automation_job" USING btree ("event_id", "created_at" DESC);--> statement-breakpoint
+ALTER TABLE "event_automation_job" ADD CONSTRAINT "event_automation_job_event_id_event_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."event"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint

--- a/apps/server/src/db/migrations/meta/0000_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0000_snapshot.json
@@ -1124,6 +1124,146 @@
 			"policies": {},
 			"checkConstraints": {},
 			"isRLSEnabled": false
+		},
+		"public.event_automation_job": {
+			"name": "event_automation_job",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"event_id": {
+					"name": "event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "event_automation_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "event_automation_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"payload": {
+					"name": "payload",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "0"
+				},
+				"last_error": {
+					"name": "last_error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"event_automation_job_event_id_type_status_unique": {
+					"name": "event_automation_job_event_id_type_status_unique",
+					"columns": [
+						{
+							"expression": "event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"event_automation_job_event_idx": {
+					"name": "event_automation_job_event_idx",
+					"columns": [
+						{
+							"expression": "event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"created_at\" desc",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"event_automation_job_event_id_event_id_fk": {
+					"name": "event_automation_job_event_id_event_id_fk",
+					"tableFrom": "event_automation_job",
+					"tableTo": "event",
+					"columnsFrom": ["event_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
 		}
 	},
 	"enums": {
@@ -1136,6 +1276,16 @@
 			"name": "provider_status",
 			"schema": "public",
 			"values": ["draft", "beta", "active", "deprecated"]
+		},
+		"public.event_automation_type": {
+			"name": "event_automation_type",
+			"schema": "public",
+			"values": ["calendar_sync", "digest_refresh"]
+		},
+		"public.event_automation_status": {
+			"name": "event_automation_status",
+			"schema": "public",
+			"values": ["pending", "processing", "completed", "failed"]
 		}
 	},
 	"schemas": {},

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
 			"when": 1759746442351,
 			"tag": "0004_event_attendee_engagement",
 			"breakpoints": false
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1759757740619,
+			"tag": "0005_event_automation_jobs",
+			"breakpoints": false
 		}
 	]
 }

--- a/apps/server/src/lib/events/automation.ts
+++ b/apps/server/src/lib/events/automation.ts
@@ -1,0 +1,60 @@
+import { randomUUID } from "node:crypto";
+
+import type { db } from "@/db";
+import {
+	eventAutomationJob,
+	eventAutomationStatus,
+	type eventAutomationType,
+} from "@/db/schema/app";
+
+export type TransactionClient = Parameters<
+	Parameters<typeof db.transaction>[0]
+>[0];
+
+type DatabaseClient = typeof db | TransactionClient;
+
+export type EventAutomationType =
+	(typeof eventAutomationType.enumValues)[number];
+export type EventAutomationStatus =
+	(typeof eventAutomationStatus.enumValues)[number];
+
+export type AutomationJobRequest = {
+	eventId: string;
+	type: EventAutomationType;
+	payload?: Record<string, unknown>;
+	scheduledAt?: Date;
+	status?: EventAutomationStatus;
+};
+
+const DEFAULT_STATUS: EventAutomationStatus =
+	eventAutomationStatus.enumValues[0];
+
+export async function enqueueEventAutomations(
+	client: DatabaseClient,
+	jobs: AutomationJobRequest[],
+): Promise<void> {
+	if (!jobs.length) return;
+
+	const rows = jobs.map(
+		(job) =>
+			({
+				id: randomUUID(),
+				eventId: job.eventId,
+				type: job.type,
+				status: job.status ?? DEFAULT_STATUS,
+				payload: job.payload ?? {},
+				scheduledAt: job.scheduledAt ?? new Date(),
+			}) satisfies typeof eventAutomationJob.$inferInsert,
+	);
+
+	await client
+		.insert(eventAutomationJob)
+		.values(rows)
+		.onConflictDoNothing({
+			target: [
+				eventAutomationJob.eventId,
+				eventAutomationJob.type,
+				eventAutomationJob.status,
+			],
+		});
+}


### PR DESCRIPTION
## Summary
- add an `event_automation_job` queue and helper to fan out calendar sync/digest work from approvals
- wire event status mutations to manage publication state and enqueue downstream automation in one transaction
- refresh the admin event UI to reflect publish-vs-status state, expose new bulk actions, and surface automation errors

## Testing
- `bun run check` *(fails: repository has pre-existing Biome configuration and CSS at-rule warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68e3c3b494788327bd1b9aecefb919f1