### PR TITLE
feat: add Google Calendar sync jobs and ICS feed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,12 @@ STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 
+# Google Calendar integration (service account credentials)
+GOOGLE_CALENDAR_CLIENT_EMAIL=
+GOOGLE_CALENDAR_PRIVATE_KEY=
+# Optional: user to impersonate when using domain-wide delegation
+GOOGLE_CALENDAR_IMPERSONATED_USER=
+
 # Protect cron endpoints (optional)
 CRON_SECRET=
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -71,7 +71,8 @@
 		"sonner": "^2.0.7",
 		"stripe": "^16.10.0",
 		"tailwind-merge": "^3.3.1",
-		"uuid": "^13.0.0"
+		"uuid": "^13.0.0",
+		"googleapis": "^140.0.0"
 	},
 	"devDependencies": {
 		"@tailwindcss/postcss": "^4",

--- a/apps/server/src/app/(api)/api/calendar/[org].ics/route.ts
+++ b/apps/server/src/app/(api)/api/calendar/[org].ics/route.ts
@@ -1,0 +1,129 @@
+import { and, eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import { event } from "@/db/schema/app";
+import { organization } from "@/db/schema/auth";
+import { buildICS } from "@/lib/calendar-links";
+
+export const runtime = "nodejs";
+
+function escapeText(value: string): string {
+	return value
+		.replace(/\\/g, "\\\\")
+		.replace(/;/g, "\\;")
+		.replace(/,/g, "\\,")
+		.replace(/\r?\n/g, "\\n");
+}
+
+function extractEventLines(document: string): string[] {
+	const lines = document.split(/\r?\n/);
+	const start = lines.indexOf("BEGIN:VEVENT");
+	const end = lines.indexOf("END:VEVENT");
+	if (start === -1 || end === -1 || end <= start) {
+		return [];
+	}
+	return lines.slice(start, end + 1);
+}
+
+function buildCalendarFeed(
+	name: string,
+	events: Array<{
+		id: string;
+		title: string;
+		description: string | null;
+		location: string | null;
+		url: string | null;
+		startAt: Date;
+		endAt: Date | null;
+		metadata: Record<string, unknown> | null;
+	}>,
+): string {
+	const calendarLines = [
+		"BEGIN:VCALENDAR",
+		"VERSION:2.0",
+		"PRODID:-//CalendarSync//EN",
+		"CALSCALE:GREGORIAN",
+		"METHOD:PUBLISH",
+		`X-WR-CALNAME:${escapeText(name)}`,
+	];
+
+	for (const event of events) {
+		const ics = buildICS({
+			id: event.id,
+			title: event.title,
+			startAt: event.startAt,
+			endAt: event.endAt ?? undefined,
+			description: event.description ?? undefined,
+			location: event.location ?? undefined,
+			url: event.url ?? undefined,
+			metadata: event.metadata ?? undefined,
+		});
+
+		const eventLines = extractEventLines(ics);
+		if (eventLines.length > 0) {
+			calendarLines.push(...eventLines);
+		}
+	}
+
+	calendarLines.push("END:VCALENDAR");
+	return calendarLines.join("\r\n");
+}
+
+export async function GET(
+	_req: Request,
+	context: { params: { org: string } },
+): Promise<Response> {
+	const slug = context.params.org;
+	if (!slug || slug.trim().length === 0) {
+		return new Response("Not found", { status: 404 });
+	}
+
+	const organizations = await db
+		.select({
+			id: organization.id,
+			name: organization.name,
+			slug: organization.slug,
+		})
+		.from(organization)
+		.where(eq(organization.slug, slug))
+		.limit(1);
+
+	const org = organizations.at(0);
+	if (!org) {
+		return new Response("Not found", { status: 404 });
+	}
+
+	const rows = await db
+		.select({
+			id: event.id,
+			title: event.title,
+			description: event.description,
+			location: event.location,
+			url: event.url,
+			startAt: event.startAt,
+			endAt: event.endAt,
+			metadata: event.metadata,
+		})
+		.from(event)
+		.where(
+			and(
+				eq(event.organizationId, org.id),
+				eq(event.status, "approved"),
+				eq(event.isPublished, true),
+			),
+		)
+		.orderBy(event.startAt, event.id);
+
+	const calendarName = org.name?.trim().length ? org.name : org.slug;
+	const payload = buildCalendarFeed(calendarName, rows);
+	const safeSlug = org.slug.replace(/[^a-z0-9_-]+/gi, "-").replace(/-+/g, "-");
+	const fileName = `${safeSlug || "calendar"}.ics`;
+
+	return new Response(payload, {
+		headers: {
+			"Content-Type": "text/calendar; charset=utf-8",
+			"Cache-Control": "public, max-age=900",
+			"Content-Disposition": `inline; filename="${fileName}"`,
+		},
+	});
+}

--- a/apps/server/src/app/(api)/api/cron/calendar/route.ts
+++ b/apps/server/src/app/(api)/api/cron/calendar/route.ts
@@ -1,0 +1,30 @@
+import { processPendingCalendarSyncJobs } from "@/lib/events/calendar-sync";
+
+export const runtime = "nodejs";
+
+async function handleRequest(req: Request) {
+	const cronSecret = process.env.CRON_SECRET;
+	if (cronSecret) {
+		const provided = req.headers.get("x-cron-secret");
+		if (provided !== cronSecret) {
+			return new Response("Unauthorized", { status: 401 });
+		}
+	}
+
+	try {
+		const summary = await processPendingCalendarSyncJobs();
+		return Response.json({ summary });
+	} catch (error) {
+		const message =
+			error instanceof Error ? error.message : "Calendar sync failed";
+		return Response.json({ error: message }, { status: 500 });
+	}
+}
+
+export async function GET(req: Request) {
+	return handleRequest(req);
+}
+
+export async function POST(req: Request) {
+	return handleRequest(req);
+}

--- a/apps/server/src/db/migrations/0006_google_calendar_sync.sql
+++ b/apps/server/src/db/migrations/0006_google_calendar_sync.sql
@@ -1,5 +1,2 @@
-ALTER TABLE "organization_provider"
-        ADD COLUMN "config" jsonb NOT NULL DEFAULT '{}'::jsonb;
-
 ALTER TABLE "event"
-        ADD COLUMN "google_calendar_event_id" text;
+	ADD COLUMN "google_calendar_event_id" text;

--- a/apps/server/src/db/migrations/0006_google_calendar_sync.sql
+++ b/apps/server/src/db/migrations/0006_google_calendar_sync.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "organization_provider"
+        ADD COLUMN "config" jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE "event"
+        ADD COLUMN "google_calendar_event_id" text;

--- a/apps/server/src/db/migrations/meta/0000_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0000_snapshot.json
@@ -82,6 +82,12 @@
 					"primaryKey": false,
 					"notNull": false
 				},
+				"google_calendar_event_id": {
+					"name": "google_calendar_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
 				"metadata": {
 					"name": "metadata",
 					"type": "jsonb",
@@ -405,6 +411,13 @@
 					"type": "text",
 					"primaryKey": false,
 					"notNull": true
+				},
+				"config": {
+					"name": "config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
 				}
 			},
 			"indexes": {

--- a/apps/server/src/db/migrations/meta/0000_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0000_snapshot.json
@@ -411,13 +411,6 @@
 					"type": "text",
 					"primaryKey": false,
 					"notNull": true
-				},
-				"config": {
-					"name": "config",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'{}'::jsonb"
 				}
 			},
 			"indexes": {

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
 			"when": 1759757740619,
 			"tag": "0005_event_automation_jobs",
 			"breakpoints": false
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1759759740619,
+			"tag": "0006_google_calendar_sync",
+			"breakpoints": false
 		}
 	]
 }

--- a/apps/server/src/db/schema/app.ts
+++ b/apps/server/src/db/schema/app.ts
@@ -119,6 +119,10 @@ export const organizationProvider = pgTable(
 		providerId: text("provider_id")
 			.notNull()
 			.references(() => provider.id, { onDelete: "cascade" }),
+		config: jsonb("config")
+			.$type<Record<string, unknown>>()
+			.notNull()
+			.default(sql`'{}'::jsonb`),
 	},
 	(table) => ({
 		organizationProviderUnique: uniqueIndex(
@@ -175,6 +179,7 @@ export const event = pgTable(
 		isAllDay: boolean("is_all_day").default(false).notNull(),
 		isPublished: boolean("is_published").default(false).notNull(),
 		externalId: text("external_id"),
+		googleCalendarEventId: text("google_calendar_event_id"),
 		metadata: jsonb("metadata")
 			.$type<Record<string, unknown>>()
 			.default(sql`'{}'::jsonb`)

--- a/apps/server/src/db/schema/app.ts
+++ b/apps/server/src/db/schema/app.ts
@@ -119,10 +119,6 @@ export const organizationProvider = pgTable(
 		providerId: text("provider_id")
 			.notNull()
 			.references(() => provider.id, { onDelete: "cascade" }),
-		config: jsonb("config")
-			.$type<Record<string, unknown>>()
-			.notNull()
-			.default(sql`'{}'::jsonb`),
 	},
 	(table) => ({
 		organizationProviderUnique: uniqueIndex(

--- a/apps/server/src/lib/events/calendar-sync.ts
+++ b/apps/server/src/lib/events/calendar-sync.ts
@@ -1,0 +1,272 @@
+import { and, eq, lte } from "drizzle-orm";
+
+import { db } from "@/db";
+import {
+	event,
+	eventAutomationJob,
+	organizationProvider,
+	provider,
+} from "@/db/schema/app";
+import {
+	deleteGoogleCalendarEvent,
+	type GoogleCalendarEventInput,
+	isGoogleCalendarConfigured,
+	upsertGoogleCalendarEvent,
+} from "@/lib/integrations/google-calendar";
+
+const DEFAULT_BATCH_SIZE = 10;
+
+type SyncAction = "created" | "updated" | "deleted" | "skipped";
+
+type OrganizationCalendarConfig = {
+	calendarId: string;
+};
+
+type EventRow = {
+	id: string;
+	title: string;
+	description: string | null;
+	location: string | null;
+	url: string | null;
+	startAt: Date;
+	endAt: Date | null;
+	isAllDay: boolean;
+	isPublished: boolean;
+	status: (typeof event.status.enumValues)[number];
+	metadata: Record<string, unknown> | null;
+	organizationId: string | null;
+	googleCalendarEventId: string | null;
+};
+
+type CalendarSyncSummary = {
+	total: number;
+	processed: number;
+	created: number;
+	updated: number;
+	deleted: number;
+	skipped: number;
+	failed: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseCalendarId(config: Record<string, unknown>): string | null {
+	const raw = config.calendarId ?? config.calendar_id ?? config.id;
+	if (typeof raw !== "string") return null;
+	const trimmed = raw.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+async function resolveOrganizationCalendar(
+	organizationId: string,
+): Promise<OrganizationCalendarConfig | null> {
+	const rows = await db
+		.select({ config: organizationProvider.config })
+		.from(organizationProvider)
+		.innerJoin(provider, eq(provider.id, organizationProvider.providerId))
+		.where(
+			and(
+				eq(organizationProvider.organizationId, organizationId),
+				eq(provider.category, "google"),
+			),
+		)
+		.limit(5);
+
+	for (const row of rows) {
+		if (!row.config || !isRecord(row.config)) continue;
+		const calendarId = parseCalendarId(row.config);
+		if (calendarId) {
+			return { calendarId } satisfies OrganizationCalendarConfig;
+		}
+	}
+
+	return null;
+}
+
+function toGoogleCalendarInput(row: EventRow): GoogleCalendarEventInput {
+	return {
+		id: row.id,
+		title: row.title,
+		startAt: row.startAt,
+		endAt: row.endAt,
+		isAllDay: row.isAllDay,
+		description: row.description ?? undefined,
+		location: row.location ?? undefined,
+		url: row.url ?? undefined,
+		metadata: row.metadata ?? undefined,
+	} satisfies GoogleCalendarEventInput;
+}
+
+export async function syncEventWithGoogleCalendar(
+	eventId: string,
+): Promise<SyncAction> {
+	if (!isGoogleCalendarConfigured()) {
+		throw new Error("Google Calendar integration is not configured");
+	}
+
+	const rows = await db
+		.select({
+			id: event.id,
+			title: event.title,
+			description: event.description,
+			location: event.location,
+			url: event.url,
+			startAt: event.startAt,
+			endAt: event.endAt,
+			isAllDay: event.isAllDay,
+			isPublished: event.isPublished,
+			status: event.status,
+			metadata: event.metadata,
+			organizationId: event.organizationId,
+			googleCalendarEventId: event.googleCalendarEventId,
+		})
+		.from(event)
+		.where(eq(event.id, eventId))
+		.limit(1);
+
+	const current = rows.at(0) as EventRow | undefined;
+	if (!current) {
+		return "skipped";
+	}
+
+	if (!current.organizationId) {
+		if (current.googleCalendarEventId) {
+			throw new Error("Cannot sync event without an owning organization");
+		}
+		return "skipped";
+	}
+
+	const calendarConfig = await resolveOrganizationCalendar(
+		current.organizationId,
+	);
+	if (!calendarConfig) {
+		throw new Error("Organization is not linked to a Google Calendar");
+	}
+
+	if (current.status !== "approved" || !current.isPublished) {
+		if (!current.googleCalendarEventId) {
+			return "skipped";
+		}
+
+		await deleteGoogleCalendarEvent({
+			calendarId: calendarConfig.calendarId,
+			eventId: current.googleCalendarEventId,
+		});
+
+		await db
+			.update(event)
+			.set({ googleCalendarEventId: null })
+			.where(eq(event.id, current.id));
+
+		return "deleted";
+	}
+
+	const googleEventId = await upsertGoogleCalendarEvent({
+		calendarId: calendarConfig.calendarId,
+		existingEventId: current.googleCalendarEventId,
+		event: toGoogleCalendarInput(current),
+	});
+
+	if (googleEventId !== current.googleCalendarEventId) {
+		await db
+			.update(event)
+			.set({ googleCalendarEventId: googleEventId })
+			.where(eq(event.id, current.id));
+	}
+
+	return current.googleCalendarEventId ? "updated" : "created";
+}
+
+export async function processPendingCalendarSyncJobs(
+	limit = DEFAULT_BATCH_SIZE,
+): Promise<CalendarSyncSummary> {
+	const now = new Date();
+	const pendingJobs = await db
+		.select({
+			id: eventAutomationJob.id,
+			eventId: eventAutomationJob.eventId,
+			attempts: eventAutomationJob.attempts,
+		})
+		.from(eventAutomationJob)
+		.where(
+			and(
+				eq(eventAutomationJob.type, "calendar_sync"),
+				eq(eventAutomationJob.status, "pending"),
+				lte(eventAutomationJob.scheduledAt, now),
+			),
+		)
+		.orderBy(eventAutomationJob.scheduledAt)
+		.limit(limit);
+
+	const summary: CalendarSyncSummary = {
+		total: pendingJobs.length,
+		processed: 0,
+		created: 0,
+		updated: 0,
+		deleted: 0,
+		skipped: 0,
+		failed: 0,
+	};
+
+	for (const job of pendingJobs) {
+		const [claimed] = await db
+			.update(eventAutomationJob)
+			.set({
+				status: "processing",
+				attempts: job.attempts + 1,
+			})
+			.where(
+				and(
+					eq(eventAutomationJob.id, job.id),
+					eq(eventAutomationJob.status, "pending"),
+				),
+			)
+			.returning({
+				id: eventAutomationJob.id,
+				eventId: eventAutomationJob.eventId,
+			});
+
+		if (!claimed) {
+			continue;
+		}
+
+		summary.processed += 1;
+
+		try {
+			const action = await syncEventWithGoogleCalendar(claimed.eventId);
+
+			switch (action) {
+				case "created":
+					summary.created += 1;
+					break;
+				case "updated":
+					summary.updated += 1;
+					break;
+				case "deleted":
+					summary.deleted += 1;
+					break;
+				case "skipped":
+					summary.skipped += 1;
+					break;
+			}
+
+			await db
+				.update(eventAutomationJob)
+				.set({ status: "completed", lastError: null })
+				.where(eq(eventAutomationJob.id, job.id));
+		} catch (error) {
+			summary.failed += 1;
+			const message =
+				error instanceof Error ? error.message : "Unknown calendar sync error";
+
+			await db
+				.update(eventAutomationJob)
+				.set({ status: "failed", lastError: message })
+				.where(eq(eventAutomationJob.id, job.id));
+		}
+	}
+
+	return summary;
+}

--- a/apps/server/src/lib/events/calendar-sync.ts
+++ b/apps/server/src/lib/events/calendar-sync.ts
@@ -63,7 +63,7 @@ async function resolveOrganizationCalendar(
 	organizationId: string,
 ): Promise<OrganizationCalendarConfig | null> {
 	const rows = await db
-		.select({ config: organizationProvider.config })
+		.select({ config: provider.config })
 		.from(organizationProvider)
 		.innerJoin(provider, eq(provider.id, organizationProvider.providerId))
 		.where(

--- a/apps/server/src/lib/integrations/google-calendar.ts
+++ b/apps/server/src/lib/integrations/google-calendar.ts
@@ -1,0 +1,279 @@
+import { type calendar_v3, google } from "googleapis";
+
+import { getEventTimezone } from "@/lib/calendar-links";
+
+const SCOPES = ["https://www.googleapis.com/auth/calendar"] as const;
+const DEFAULT_MEETING_LENGTH_MS = 60 * 60 * 1000;
+
+export type GoogleCalendarEventInput = {
+	id: string;
+	title: string;
+	startAt: Date;
+	endAt: Date | null;
+	isAllDay: boolean;
+	description?: string | null;
+	location?: string | null;
+	url?: string | null;
+	metadata?: Record<string, unknown> | null;
+};
+
+type ServiceAccountConfig = {
+	clientEmail: string;
+	privateKey: string;
+	impersonatedUser?: string;
+};
+
+let cachedConfig: ServiceAccountConfig | null = null;
+
+function getServiceAccountConfig(): ServiceAccountConfig {
+	if (cachedConfig) {
+		return cachedConfig;
+	}
+
+	const clientEmail = process.env.GOOGLE_CALENDAR_CLIENT_EMAIL?.trim();
+	const privateKey = process.env.GOOGLE_CALENDAR_PRIVATE_KEY;
+
+	if (!clientEmail || !privateKey) {
+		throw new Error(
+			"Google Calendar service account credentials are not configured",
+		);
+	}
+
+	const normalizedKey = privateKey.includes("\\n")
+		? privateKey.replace(/\\n/g, "\n")
+		: privateKey;
+
+	const impersonatedUser =
+		process.env.GOOGLE_CALENDAR_IMPERSONATED_USER?.trim();
+
+	cachedConfig = {
+		clientEmail,
+		privateKey: normalizedKey,
+		impersonatedUser:
+			impersonatedUser && impersonatedUser.length > 0
+				? impersonatedUser
+				: undefined,
+	} satisfies ServiceAccountConfig;
+
+	return cachedConfig;
+}
+
+export function isGoogleCalendarConfigured(): boolean {
+	try {
+		getServiceAccountConfig();
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function getCalendarClient(): Promise<calendar_v3.Calendar> {
+	const config = getServiceAccountConfig();
+	const auth = new google.auth.JWT({
+		email: config.clientEmail,
+		key: config.privateKey,
+		scopes: SCOPES,
+		subject: config.impersonatedUser,
+	});
+
+	await auth.authorize();
+
+	return google.calendar({ version: "v3", auth });
+}
+
+type DateParts = {
+	year: number;
+	month: number;
+	day: number;
+};
+
+function extractDateParts(date: Date, timeZone?: string): DateParts {
+	const formatter = new Intl.DateTimeFormat("en-CA", {
+		timeZone,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	});
+
+	const parts = formatter
+		.formatToParts(date)
+		.reduce<Record<string, string>>((acc, part) => {
+			if (part.type !== "literal") {
+				acc[part.type] = part.value;
+			}
+			return acc;
+		}, {});
+
+	const year = Number(parts.year);
+	const month = Number(parts.month);
+	const day = Number(parts.day);
+
+	if (
+		!Number.isFinite(year) ||
+		!Number.isFinite(month) ||
+		!Number.isFinite(day)
+	) {
+		throw new Error("Invalid date parts");
+	}
+
+	return { year, month, day } satisfies DateParts;
+}
+
+function shiftDateParts(parts: DateParts, days: number): DateParts {
+	const base = new Date(Date.UTC(parts.year, parts.month - 1, parts.day));
+	base.setUTCDate(base.getUTCDate() + days);
+	const shifted = extractDateParts(base, "UTC");
+	return shifted;
+}
+
+function formatDateParts(parts: DateParts): string {
+	const year = String(parts.year).padStart(4, "0");
+	const month = String(parts.month).padStart(2, "0");
+	const day = String(parts.day).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+}
+
+function formatDateOnly(date: Date, timeZone?: string, offsetDays = 0): string {
+	try {
+		const parts = extractDateParts(date, timeZone);
+		const shifted =
+			offsetDays === 0 ? parts : shiftDateParts(parts, offsetDays);
+		return formatDateParts(shifted);
+	} catch {
+		const adjusted = new Date(date);
+		if (offsetDays !== 0) {
+			adjusted.setUTCDate(adjusted.getUTCDate() + offsetDays);
+		}
+		return adjusted.toISOString().slice(0, 10);
+	}
+}
+
+function resolveEndDate(start: Date, rawEnd: Date | null): Date {
+	if (!rawEnd || Number.isNaN(rawEnd.getTime())) {
+		return new Date(start.getTime() + DEFAULT_MEETING_LENGTH_MS);
+	}
+
+	if (rawEnd.getTime() <= start.getTime()) {
+		return new Date(start.getTime() + DEFAULT_MEETING_LENGTH_MS);
+	}
+
+	return rawEnd;
+}
+
+function buildEventResource(
+	event: GoogleCalendarEventInput,
+): calendar_v3.Schema$Event {
+	const timezone = getEventTimezone({
+		id: event.id,
+		title: event.title,
+		startAt: event.startAt,
+		endAt: event.endAt ?? undefined,
+		metadata: event.metadata ?? undefined,
+	});
+
+	const resource: calendar_v3.Schema$Event = {
+		summary: event.title,
+		description: event.description ?? undefined,
+		location: event.location ?? undefined,
+		status: "confirmed",
+		transparency: "opaque",
+		source:
+			event.url && event.url.trim().length > 0
+				? { title: event.title, url: event.url }
+				: undefined,
+		reminders: { useDefault: true },
+	};
+
+	if (event.isAllDay) {
+		const startDate = formatDateOnly(event.startAt, timezone, 0);
+		const endSeed = event.endAt ?? event.startAt;
+		const exclusiveEnd = formatDateOnly(endSeed, timezone, 1);
+		resource.start = { date: startDate };
+		resource.end = { date: exclusiveEnd };
+	} else {
+		const endAt = resolveEndDate(event.startAt, event.endAt);
+		resource.start = {
+			dateTime: event.startAt.toISOString(),
+			timeZone: timezone,
+		};
+		resource.end = {
+			dateTime: endAt.toISOString(),
+			timeZone: timezone,
+		};
+	}
+
+	return resource;
+}
+
+export async function upsertGoogleCalendarEvent({
+	calendarId,
+	event,
+	existingEventId,
+}: {
+	calendarId: string;
+	event: GoogleCalendarEventInput;
+	existingEventId?: string | null;
+}): Promise<string> {
+	const client = await getCalendarClient();
+	const requestBody = buildEventResource(event);
+
+	if (existingEventId) {
+		const response = await client.events.patch({
+			calendarId,
+			eventId: existingEventId,
+			requestBody,
+		});
+
+		return response.data.id ?? existingEventId;
+	}
+
+	const response = await client.events.insert({
+		calendarId,
+		requestBody,
+	});
+
+	const id = response.data.id;
+	if (!id) {
+		throw new Error("Google Calendar did not return an event identifier");
+	}
+
+	return id;
+}
+
+function isNotFoundError(error: unknown): boolean {
+	if (!error) return false;
+
+	const maybeCode = (error as { code?: number }).code;
+	if (maybeCode === 404) return true;
+
+	const maybeStatus = (error as { status?: number }).status;
+	if (maybeStatus === 404) return true;
+
+	const responseStatus = (error as { response?: { status?: number } }).response
+		?.status;
+	if (responseStatus === 404) return true;
+
+	return false;
+}
+
+export async function deleteGoogleCalendarEvent({
+	calendarId,
+	eventId,
+}: {
+	calendarId: string;
+	eventId: string;
+}): Promise<void> {
+	const client = await getCalendarClient();
+
+	try {
+		await client.events.delete({
+			calendarId,
+			eventId,
+		});
+	} catch (error) {
+		if (isNotFoundError(error)) {
+			return;
+		}
+		throw error;
+	}
+}

--- a/apps/server/src/routers/events.ts
+++ b/apps/server/src/routers/events.ts
@@ -440,6 +440,7 @@ type EventSelection = {
 	isAllDay: boolean;
 	isPublished: boolean;
 	externalId: string | null;
+	googleCalendarEventId: string | null;
 	metadata: Record<string, unknown> | null;
 	status: (typeof event.status.enumValues)[number];
 	priority: number;
@@ -796,6 +797,7 @@ const eventSelection = {
 	isAllDay: event.isAllDay,
 	isPublished: event.isPublished,
 	externalId: event.externalId,
+	googleCalendarEventId: event.googleCalendarEventId,
 	metadata: event.metadata,
 	status: event.status,
 	priority: event.priority,
@@ -932,6 +934,7 @@ function mapEvent(row: EventSelection) {
 		isAllDay: row.isAllDay,
 		isPublished: row.isPublished,
 		externalId: row.externalId,
+		googleCalendarEventId: row.googleCalendarEventId,
 		metadata,
 		autoApproval,
 		status: row.status,

--- a/bun.lock
+++ b/bun.lock
@@ -3,9 +3,6 @@
   "workspaces": {
     "": {
       "name": "calendar-sync",
-      "dependencies": {
-        "resend": "^6.1.2",
-      },
       "devDependencies": {
         "@biomejs/biome": "^2.2.0",
       },
@@ -49,6 +46,7 @@
         "dotenv": "^17.2.1",
         "drizzle-orm": "^0.44.2",
         "embla-carousel-react": "^8.6.0",
+        "googleapis": "^140.0.0",
         "hono": "^4.9.8",
         "imapflow": "^1.0.0",
         "input-otp": "^1.4.2",
@@ -720,6 +718,8 @@
 
     "@wojtekmaj/react-recaptcha-v3": ["@wojtekmaj/react-recaptcha-v3@0.1.4", "", { "dependencies": { "warning": "^4.0.0" }, "peerDependencies": { "@types/react": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-zszMOdgI+y1Dz3496pRFr3t68n9+OmX/puLQNnOBDC7WrjM+nOKGyjIMCTe+3J14KDvzcxETeiglyDMGl0Yh/Q=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "ai": ["ai@5.0.47", "", { "dependencies": { "@ai-sdk/gateway": "1.0.24", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.9", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-/DKfU9tTsQVcUYSDCTu1L7jmvEgzUWOr1xf5UHwwDbRf/HED8LDb60QlWYs6f4BkZsVoLvpliCSjliXiRZywFQ=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
@@ -730,11 +730,17 @@
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "better-auth": ["better-auth@1.3.11", "", { "dependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "^1.1.18", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^2.0.0", "@simplewebauthn/browser": "^13.1.2", "@simplewebauthn/server": "^13.1.2", "better-call": "1.0.19", "defu": "^6.1.4", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1", "zod": "^4.1.5" }, "peerDependencies": { "@lynx-js/react": "*", "@sveltejs/kit": "^2.0.0", "next": "^14.0.0 || ^15.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@sveltejs/kit", "next", "react", "react-dom", "solid-js", "svelte", "vue"] }, "sha512-7l8bHX5rnON4vsVmWB7g2UucNpRlXnDUX/n65mHeR3Zn2/lcpQvfBvGbTaHYU8UGCQadtJ7DLHW/zA3ZR7IfdA=="],
 
     "better-call": ["better-call@1.0.19", "", { "dependencies": { "@better-auth/utils": "^0.3.0", "@better-fetch/fetch": "^1.1.4", "rou3": "^0.5.1", "set-cookie-parser": "^2.7.1", "uncrypto": "^0.1.3" } }, "sha512-sI3GcA1SCVa3H+CDHl8W8qzhlrckwXOTKhqq3OOPXjgn5aTOMIqGY34zLY/pHA6tRRMjTUC3lz5Mi7EbDA24Kw=="],
 
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
     "bowser": ["bowser@2.12.1", "", {}, "sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -810,6 +816,8 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
     "elen": ["elen@1.0.10", "", {}, "sha512-ZL799/V/kzxYJ6Wlfktreq6qQWfGc3VkGUQJW5lZQ8/MhsQiKTAwERPfhEwIsV2movRGe2DfV7H2MjRw76Z7Wg=="],
 
     "embla-carousel": ["embla-carousel@8.6.0", "", {}, "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA=="],
@@ -836,6 +844,8 @@
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
     "fast-deep-equal": ["fast-deep-equal@2.0.1", "", {}, "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="],
 
     "fast-redact": ["fast-redact@3.5.0", "", {}, "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A=="],
@@ -843,6 +853,10 @@
     "fast-xml-parser": ["fast-xml-parser@5.2.5", "", { "dependencies": { "strnum": "^2.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gaxios": ["gaxios@6.7.1", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "is-stream": "^2.0.0", "node-fetch": "^2.6.9", "uuid": "^9.0.1" } }, "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ=="],
+
+    "gcp-metadata": ["gcp-metadata@6.1.1", "", { "dependencies": { "gaxios": "^6.1.1", "google-logging-utils": "^0.0.2", "json-bigint": "^1.0.0" } }, "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
@@ -854,9 +868,19 @@
 
     "globalize": ["globalize@0.1.1", "", {}, "sha512-5e01v8eLGfuQSOvx2MsDMOWS0GFtCx1wPzQSmcHw4hkxFzrQDBO3Xwg/m8Hr/7qXMrHeOIE29qWVzyv06u1TZA=="],
 
+    "google-auth-library": ["google-auth-library@9.15.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^6.1.1", "gcp-metadata": "^6.1.0", "gtoken": "^7.0.0", "jws": "^4.0.0" } }, "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng=="],
+
+    "google-logging-utils": ["google-logging-utils@0.0.2", "", {}, "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="],
+
+    "googleapis": ["googleapis@140.0.1", "", { "dependencies": { "google-auth-library": "^9.0.0", "googleapis-common": "^7.0.0" } }, "sha512-ZGvBX4mQcFXO9ACnVNg6Aqy3KtBPB5zTuue43YVLxwn8HSv8jB7w+uDKoIPSoWuxGROgnj2kbng6acXncOQRNA=="],
+
+    "googleapis-common": ["googleapis-common@7.2.0", "", { "dependencies": { "extend": "^3.0.2", "gaxios": "^6.0.3", "google-auth-library": "^9.7.0", "qs": "^6.7.0", "url-template": "^2.0.8", "uuid": "^9.0.0" } }, "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA=="],
+
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "gtoken": ["gtoken@7.1.0", "", { "dependencies": { "gaxios": "^6.0.0", "jws": "^4.0.0" } }, "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -871,6 +895,8 @@
     "html-to-text": ["html-to-text@9.0.5", "", { "dependencies": { "@selderee/plugin-htmlparser2": "^0.11.0", "deepmerge": "^4.3.1", "dom-serializer": "^2.0.0", "htmlparser2": "^8.0.2", "selderee": "^0.11.0" } }, "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg=="],
 
     "htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "iconv-lite": ["iconv-lite@0.7.0", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ=="],
 
@@ -890,6 +916,8 @@
 
     "is-standalone-pwa": ["is-standalone-pwa@0.1.1", "", {}, "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g=="],
 
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
     "is-what": ["is-what@4.1.16", "", {}, "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A=="],
 
     "jiti": ["jiti@2.5.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w=="],
@@ -898,7 +926,13 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.0", "", { "dependencies": { "jwa": "^2.0.0", "safe-buffer": "^5.0.1" } }, "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg=="],
 
     "kysely": ["kysely@0.28.7", "", {}, "sha512-u/cAuTL4DRIiO2/g4vNGRgklEKNIj5Q3CG7RoUB5DV5SfEC2hMvPxKi0GWPmnzwL2ryIeud2VTcEEmqzTzEPNw=="],
 
@@ -979,6 +1013,8 @@
     "next": ["next@15.5.0", "", { "dependencies": { "@next/env": "15.5.0", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.0", "@next/swc-darwin-x64": "15.5.0", "@next/swc-linux-arm64-gnu": "15.5.0", "@next/swc-linux-arm64-musl": "15.5.0", "@next/swc-linux-x64-gnu": "15.5.0", "@next/swc-linux-x64-musl": "15.5.0", "@next/swc-win32-arm64-msvc": "15.5.0", "@next/swc-win32-x64-msvc": "15.5.0", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-N1lp9Hatw3a9XLt0307lGB4uTKsXDhyOKQo7uYMzX4i0nF/c27grcGXkLdb7VcT8QPYLBa8ouIyEoUQJ2OyeNQ=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
+
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "nodemailer": ["nodemailer@6.10.1", "", {}, "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA=="],
 
@@ -1092,6 +1128,8 @@
 
     "rou3": ["rou3@0.5.1", "", {}, "sha512-OXMmJ3zRk2xeXFGfA3K+EOPHC5u7RDFG7lIOx0X1pdnhUkI8MdVrbV+sNsD80ElpUZ+MRHdyxPnFthq9VHs8uQ=="],
 
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
@@ -1160,6 +1198,8 @@
 
     "tlds": ["tlds@1.259.0", "", { "bin": { "tlds": "bin.js" } }, "sha512-AldGGlDP0PNgwppe2quAvuBl18UcjuNtOnDuUkqhd6ipPqrYYBt3aTxK1QTsBVknk97lS2JcafWMghjGWFtunw=="],
 
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
@@ -1182,6 +1222,8 @@
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "url-template": ["url-template@2.0.8", "", {}, "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="],
+
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
@@ -1195,6 +1237,10 @@
     "warning": ["warning@4.0.3", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w=="],
 
     "web-worker": ["web-worker@1.5.0", "", {}, "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw=="],
+
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "worker": ["worker@workspace:apps/worker"],
 
@@ -1233,6 +1279,10 @@
     "@types/mailparser/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "better-auth/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+
+    "gaxios/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "googleapis-common/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "imapflow/nodemailer": ["nodemailer@7.0.6", "", {}, "sha512-F44uVzgwo49xboqbFgBGkRaiMgtoBrBEWCVincJPK9+S9Adkzt/wXCLKbf7dxucmxfTI5gHGB+bEmdyzN6QKjw=="],
 


### PR DESCRIPTION
## Summary
- extend configuration, schema, and migrations to persist Google Calendar credentials plus per-event sync identifiers
- add a Google Calendar integration module and automation worker to upsert or delete events when calendar sync jobs are processed
- expose a cron endpoint for calendar syncing and publish an organization ICS feed powered by the existing buildICS helper

## Testing
- bun run check *(fails: existing lint/style violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68e3d4bcf07c8327879ce5dd4b67a1ea