### PR TITLE
feat: add email digest scheduling and admin controls

### DIFF
--- a/apps/server/src/app/(api)/api/cron/emails/route.ts
+++ b/apps/server/src/app/(api)/api/cron/emails/route.ts
@@ -1,3 +1,4 @@
+import { scheduleDigestDeliveries } from "@/lib/mailer/digest";
 import {
 	processPendingEmailDeliveries,
 	scheduleEventCommunications,
@@ -14,11 +15,15 @@ async function handleRequest(req: Request) {
 		}
 	}
 
+	const digestFeatureEnabled = process.env.FEATURE_DIGEST_EMAILS === "true";
 	const scheduled = await scheduleEventCommunications();
+	const digest = digestFeatureEnabled ? await scheduleDigestDeliveries() : null;
 	const processed = await processPendingEmailDeliveries();
 
 	return Response.json({
 		scheduled,
+		digest,
+		digestFeatureEnabled,
 		processed,
 	});
 }

--- a/apps/server/src/app/(site)/admin/digests/page.tsx
+++ b/apps/server/src/app/(site)/admin/digests/page.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { RedirectToSignIn } from "@daveyplate/better-auth-ui";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { formatDistanceToNowStrict } from "date-fns";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import AppShell from "@/components/layout/AppShell";
+import { UserAvatar } from "@/components/UserAvatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardFooter,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import { digestKeys } from "@/lib/query-keys/digests";
+import { trpcClient } from "@/lib/trpc-client";
+
+const segmentDescriptions: Record<string, string> = {
+	joined: "Members receive highlights from organizations they belong to.",
+	discover: "Showcase recommended events from new organizations.",
+};
+
+type Schedule = Awaited<
+	ReturnType<typeof trpcClient.adminDigests.listSchedules.query>
+>[number];
+
+type Draft = {
+	enabled: boolean;
+	cadenceHours: string;
+	lookaheadDays: string;
+};
+
+function formatTimestamp(value: string | null) {
+	if (!value) return null;
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) return null;
+	return formatDistanceToNowStrict(date, { addSuffix: true });
+}
+
+function computeNextSend(schedule: Schedule) {
+	if (!schedule.lastSentAt) return null;
+	const base = new Date(schedule.lastSentAt);
+	if (Number.isNaN(base.getTime())) return null;
+	const next = new Date(
+		base.getTime() + schedule.cadenceHours * 60 * 60 * 1000,
+	);
+	return next.toISOString();
+}
+
+export default function AdminDigestsPage() {
+        const queryClient = useQueryClient();
+        const scheduleQuery = useQuery({
+                queryKey: digestKeys.schedules(),
+                queryFn: () => trpcClient.adminDigests.listSchedules.query(),
+        });
+        const [drafts, setDrafts] = useState<Record<string, Draft>>({});
+        const placeholders = ["primary", "secondary"] as const;
+
+	useEffect(() => {
+		if (!scheduleQuery.data) return;
+		const mapped: Record<string, Draft> = {};
+		for (const schedule of scheduleQuery.data) {
+			mapped[schedule.segment] = {
+				enabled: schedule.enabled,
+				cadenceHours: schedule.cadenceHours.toString(),
+				lookaheadDays: schedule.lookaheadDays.toString(),
+			} satisfies Draft;
+		}
+		setDrafts(mapped);
+	}, [scheduleQuery.data]);
+
+	const mutation = useMutation({
+		mutationFn: (input: {
+			segment: Schedule["segment"];
+			enabled: boolean;
+			cadenceHours: number;
+			lookaheadDays: number;
+		}) => trpcClient.adminDigests.updateSchedule.mutate(input),
+		onSuccess: (updated) => {
+			queryClient.invalidateQueries({ queryKey: digestKeys.schedules() });
+			toast.success("Digest schedule updated", {
+				description: `${updated.segment} cadence saved.`,
+			});
+		},
+		onError: (error) => {
+			toast.error(
+				error instanceof Error
+					? error.message
+					: "Unable to update digest schedule",
+			);
+		},
+	});
+
+	const schedules = scheduleQuery.data ?? [];
+	const isLoading = scheduleQuery.isLoading;
+	const isError = scheduleQuery.isError;
+
+	const handleToggle = (segment: string, enabled: boolean) => {
+		setDrafts((prev) => ({
+			...prev,
+			[segment]: {
+				...(prev[segment] ?? {
+					enabled,
+					cadenceHours: "168",
+					lookaheadDays: "14",
+				}),
+				enabled,
+			},
+		}));
+	};
+
+	const handleInputChange = (
+		segment: string,
+		field: keyof Draft,
+		value: string,
+	) => {
+		setDrafts((prev) => ({
+			...prev,
+			[segment]: {
+				...(prev[segment] ?? {
+					enabled: false,
+					cadenceHours: "168",
+					lookaheadDays: "14",
+				}),
+				[field]: value,
+			},
+		}));
+	};
+
+	const handleSubmit = (schedule: Schedule) => {
+		const draft = drafts[schedule.segment];
+		if (!draft) return;
+		const cadence = Number.parseInt(draft.cadenceHours, 10);
+		const lookahead = Number.parseInt(draft.lookaheadDays, 10);
+		if (Number.isNaN(cadence) || Number.isNaN(lookahead)) {
+			toast.error("Cadence and lookahead must be numbers");
+			return;
+		}
+		mutation.mutate({
+			segment: schedule.segment,
+			enabled: draft.enabled,
+			cadenceHours: cadence,
+			lookaheadDays: lookahead,
+		});
+	};
+
+	const renderSummary = (schedule: Schedule) => {
+		const summary = schedule.metadata ?? {};
+		const recipients = Number(summary.lastQueuedRecipients ?? 0);
+		const segmentsWithEvents = Array.isArray(summary.segmentsWithEvents)
+			? summary.segmentsWithEvents.length
+			: 0;
+		const lastSent = schedule.lastSentAt
+			? formatTimestamp(schedule.lastSentAt)
+			: null;
+		const nextSendIso = computeNextSend(schedule);
+		const nextSend = nextSendIso ? formatTimestamp(nextSendIso) : null;
+		return (
+			<div className="flex flex-wrap gap-3 text-muted-foreground text-xs">
+				<Badge variant="outline">Last sent: {lastSent ?? "Never"}</Badge>
+				<Badge variant="outline">Next run: {nextSend ?? "Pending"}</Badge>
+				<Badge variant="outline">
+					Recipients queued: {Number.isFinite(recipients) ? recipients : 0}
+				</Badge>
+				<Badge variant="outline">
+					Segments w/ events: {segmentsWithEvents}
+				</Badge>
+			</div>
+		);
+	};
+
+	const renderCard = (schedule: Schedule) => {
+		const draft = drafts[schedule.segment];
+		const pending = mutation.isPending;
+		const cadenceNumber = Number.parseInt(draft?.cadenceHours ?? "0", 10);
+		const lookaheadNumber = Number.parseInt(draft?.lookaheadDays ?? "0", 10);
+		const isDirty =
+			draft?.enabled !== schedule.enabled ||
+			cadenceNumber !== schedule.cadenceHours ||
+			lookaheadNumber !== schedule.lookaheadDays;
+		const disabled = pending || !draft;
+		return (
+			<Card key={schedule.id}>
+				<CardHeader>
+					<div className="flex items-center justify-between">
+						<div>
+							<CardTitle className="text-lg capitalize">
+								{schedule.segment}
+							</CardTitle>
+							<CardDescription>
+								{segmentDescriptions[schedule.segment] ??
+									"Customize this digest segment."}
+							</CardDescription>
+						</div>
+						<Switch
+							checked={draft?.enabled ?? false}
+							onCheckedChange={(value) => handleToggle(schedule.segment, value)}
+							disabled={pending}
+						/>
+					</div>
+				</CardHeader>
+				<CardContent className="space-y-4">
+					<div className="grid gap-4 sm:grid-cols-2">
+						<div className="space-y-2">
+							<Label htmlFor={`${schedule.segment}-cadence`}>
+								Cadence (hours)
+							</Label>
+							{isLoading ? (
+								<Skeleton className="h-10 w-full" />
+							) : (
+								<Input
+									id={`${schedule.segment}-cadence`}
+									type="number"
+									min={6}
+									value={draft?.cadenceHours ?? ""}
+									onChange={(event) =>
+										handleInputChange(
+											schedule.segment,
+											"cadenceHours",
+											event.target.value,
+										)
+									}
+									disabled={pending}
+								/>
+							)}
+						</div>
+						<div className="space-y-2">
+							<Label htmlFor={`${schedule.segment}-lookahead`}>
+								Lookahead window (days)
+							</Label>
+							{isLoading ? (
+								<Skeleton className="h-10 w-full" />
+							) : (
+								<Input
+									id={`${schedule.segment}-lookahead`}
+									type="number"
+									min={1}
+									value={draft?.lookaheadDays ?? ""}
+									onChange={(event) =>
+										handleInputChange(
+											schedule.segment,
+											"lookaheadDays",
+											event.target.value,
+										)
+									}
+									disabled={pending}
+								/>
+							)}
+						</div>
+					</div>
+					{renderSummary(schedule)}
+				</CardContent>
+				<CardFooter className="flex justify-end">
+					<Button
+						onClick={() => handleSubmit(schedule)}
+						disabled={disabled || !isDirty}
+					>
+						{pending ? "Saving…" : "Save changes"}
+					</Button>
+				</CardFooter>
+			</Card>
+		);
+	};
+
+	return (
+		<AppShell
+			breadcrumbs={[
+				{ label: "Admin", href: "/admin/overview" },
+				{ label: "Email digests", current: true },
+			]}
+			headerRight={<UserAvatar />}
+		>
+			<RedirectToSignIn />
+			<section className="space-y-4">
+				<div className="flex flex-col gap-2">
+					<h1 className="font-semibold text-2xl tracking-tight">
+						Email digest cadence
+					</h1>
+					<p className="text-muted-foreground text-sm">
+						Control how often digest emails are generated and who receives each
+						segment.
+					</p>
+				</div>
+                                {isError ? (
+                                        <Card>
+                                                <CardHeader>
+                                                        <CardTitle>Unable to load schedules</CardTitle>
+                                                        <CardDescription>
+                                                                {scheduleQuery.error instanceof Error
+                                                                        ? scheduleQuery.error.message
+                                                                        : "Something went wrong while fetching digest configuration."}
+                                                        </CardDescription>
+                                                </CardHeader>
+                                        </Card>
+                                ) : (
+                                        <div className="grid gap-4 md:grid-cols-2">
+                                                {isLoading && !schedules.length
+                                                        ? placeholders.map((token) => (
+                                                                  <Skeleton key={token} className="h-48 w-full" />
+                                                          ))
+                                                        : schedules.map((schedule) => renderCard(schedule))}
+                                        </div>
+                                )}
+			</section>
+		</AppShell>
+	);
+}

--- a/apps/server/src/config/ui.ts
+++ b/apps/server/src/config/ui.ts
@@ -3,6 +3,7 @@ import {
 	FlagIcon,
 	LayoutDashboard,
 	ListTodo,
+	Mail,
 	MessageSquare,
 	Network,
 	Users,
@@ -18,6 +19,7 @@ export const defaultNavigation: NavGroup[] = [
 			{ title: "Users", href: "/admin/users", icon: Users },
 			{ title: "Providers", href: "/admin/providers", icon: Network },
 			{ title: "Flags", href: "/admin/flags", icon: FlagIcon },
+			{ title: "Email digests", href: "/admin/digests", icon: Mail },
 		],
 	},
 	{

--- a/apps/server/src/db/migrations/0007_digest_scheduling.sql
+++ b/apps/server/src/db/migrations/0007_digest_scheduling.sql
@@ -1,0 +1,17 @@
+ALTER TYPE "public"."event_email_type" ADD VALUE IF NOT EXISTS 'digest';
+
+CREATE TYPE "public"."digest_segment" AS ENUM ('joined', 'discover');
+
+CREATE TABLE "public"."digest_schedule" (
+    "id" text PRIMARY KEY NOT NULL,
+    "segment" "public"."digest_segment" NOT NULL,
+    "enabled" boolean NOT NULL DEFAULT false,
+    "cadence_hours" integer NOT NULL DEFAULT 168,
+    "lookahead_days" integer NOT NULL DEFAULT 14,
+    "last_sent_at" timestamp with time zone,
+    "metadata" jsonb NOT NULL DEFAULT '{}'::jsonb,
+    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX "digest_schedule_segment_unique" ON "public"."digest_schedule" ("segment");

--- a/apps/server/src/db/migrations/meta/0000_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0000_snapshot.json
@@ -1270,6 +1270,86 @@
 			"policies": {},
 			"checkConstraints": {},
 			"isRLSEnabled": false
+		},
+		"public.digest_schedule": {
+			"name": "digest_schedule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"segment": {
+					"name": "segment",
+					"type": "digest_segment",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"cadence_hours": {
+					"name": "cadence_hours",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 168
+				},
+				"lookahead_days": {
+					"name": "lookahead_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 14
+				},
+				"last_sent_at": {
+					"name": "last_sent_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"digest_schedule_segment_unique": {
+					"name": "digest_schedule_segment_unique",
+					"nullsNotDistinct": false,
+					"columns": ["segment"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
 		}
 	},
 	"enums": {
@@ -1292,6 +1372,29 @@
 			"name": "event_automation_status",
 			"schema": "public",
 			"values": ["pending", "processing", "completed", "failed"]
+		},
+		"public.event_email_type": {
+			"name": "event_email_type",
+			"schema": "public",
+			"values": [
+				"confirmation",
+				"reminder",
+				"update",
+				"cancellation",
+				"follow_up",
+				"announcement",
+				"digest"
+			]
+		},
+		"public.event_email_status": {
+			"name": "event_email_status",
+			"schema": "public",
+			"values": ["pending", "sending", "sent", "failed"]
+		},
+		"public.digest_segment": {
+			"name": "digest_segment",
+			"schema": "public",
+			"values": ["joined", "discover"]
 		}
 	},
 	"schemas": {},

--- a/apps/server/src/db/schema/app.ts
+++ b/apps/server/src/db/schema/app.ts
@@ -73,6 +73,7 @@ export const eventEmailType = pgEnum("event_email_type", [
 	"cancellation",
 	"follow_up",
 	"announcement",
+	"digest",
 ]);
 
 export const eventEmailStatus = pgEnum("event_email_status", [
@@ -93,6 +94,8 @@ export const eventAutomationStatus = pgEnum("event_automation_status", [
 	"completed",
 	"failed",
 ]);
+
+export const digestSegment = pgEnum("digest_segment", ["joined", "discover"]);
 
 export const provider = pgTable("provider", {
 	id: text("id").primaryKey(),
@@ -506,6 +509,28 @@ export const eventEmailDelivery = pgTable(
 	],
 );
 
+export const digestSchedule = pgTable(
+	"digest_schedule",
+	{
+		id: text("id").primaryKey(),
+		segment: digestSegment("segment").notNull(),
+		enabled: boolean("enabled").notNull().default(false),
+		cadenceHours: integer("cadence_hours").notNull().default(168),
+		lookaheadDays: integer("lookahead_days").notNull().default(14),
+		lastSentAt: timestamp("last_sent_at", { withTimezone: true }),
+		metadata: jsonb("metadata")
+			.$type<Record<string, unknown>>()
+			.notNull()
+			.default(sql`'{}'::jsonb`),
+		...timestamps,
+	},
+	(table) => ({
+		segmentUnique: uniqueIndex("digest_schedule_segment_unique").on(
+			table.segment,
+		),
+	}),
+);
+
 export type AttendeeProfile = typeof attendeeProfile.$inferSelect;
 export type TicketType = typeof ticketType.$inferSelect;
 export type EventOrder = typeof eventOrder.$inferSelect;
@@ -514,6 +539,8 @@ export type WaitlistEntry = typeof waitlistEntry.$inferSelect;
 export type Attendee = typeof attendee.$inferSelect;
 export type EventEmailDelivery = typeof eventEmailDelivery.$inferSelect;
 export type InsertEventEmailDelivery = typeof eventEmailDelivery.$inferInsert;
+export type DigestSchedule = typeof digestSchedule.$inferSelect;
+export type InsertDigestSchedule = typeof digestSchedule.$inferInsert;
 
 export const workerLog = pgTable("worker_log", {
 	id: bigserial("id", { mode: "number" }).primaryKey(),

--- a/apps/server/src/lib/mailer/digest.ts
+++ b/apps/server/src/lib/mailer/digest.ts
@@ -1,0 +1,777 @@
+import { randomUUID } from "node:crypto";
+import { format } from "date-fns";
+import { and, eq, gte, inArray, isNull, lte } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
+
+import { db } from "@/db";
+import {
+	type DigestSchedule as DigestScheduleRecord,
+	digestSchedule,
+	digestSegment,
+	event,
+	eventEmailDelivery,
+	organization,
+	organizationProvider,
+	provider,
+} from "@/db/schema/app";
+import { member, user } from "@/db/schema/auth";
+import { formatDisplayDate } from "@/lib/datetime";
+
+import { queueEmailDelivery } from "./deliveries";
+
+export type DigestSegmentValue = (typeof digestSegment.enumValues)[number];
+
+export type DigestMetadata = {
+	version: 1;
+	userId?: string;
+	summary?: {
+		totalEvents: number;
+		organizationCount: number;
+		windowStart: string;
+		windowEnd: string;
+		generatedAt: string;
+	};
+	segments?: Array<{
+		segment: DigestSegmentValue;
+		organizations: Array<{
+			id: string;
+			name: string;
+			slug: string | null;
+			events: Array<{
+				id: string;
+				title: string;
+				startAt: string;
+				endAt: string | null;
+				location: string | null;
+				url: string | null;
+			}>;
+		}>;
+	}>;
+	content: {
+		subject: string;
+		previewText: string | null;
+		html: string;
+		text: string;
+	};
+};
+
+export const DIGEST_SEGMENTS: DigestSegmentValue[] = [
+	...digestSegment.enumValues,
+];
+export const DEFAULT_DIGEST_LOOKAHEAD_DAYS = 14;
+export const DEFAULT_DIGEST_CADENCE_HOURS = 168;
+const MAX_EVENTS_PER_SEGMENT = 12;
+const MAX_EVENTS_PER_ORGANIZATION = 5;
+
+const SEGMENT_LABELS: Record<
+	DigestSegmentValue,
+	{ title: string; description: string }
+> = {
+	joined: {
+		title: "From your organizations",
+		description: "Updates from groups you've already joined.",
+	},
+	discover: {
+		title: "Discover new groups",
+		description: "Highlights from organizations you might enjoy.",
+	},
+};
+
+const GREETING_FALLBACK = "there";
+
+function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}
+
+function safeUrl(value: string | null | undefined): string | null {
+	if (!value) return null;
+	try {
+		return new URL(value).toString();
+	} catch {
+		return null;
+	}
+}
+
+function formatDateRange(start: Date, end: Date): string {
+	const startTime = start.getTime();
+	const endTime = end.getTime();
+	if (Number.isNaN(startTime) || Number.isNaN(endTime)) {
+		return "";
+	}
+	if (startTime === endTime) {
+		return format(start, "MMM d, yyyy");
+	}
+	if (start.getFullYear() === end.getFullYear()) {
+		if (start.getMonth() === end.getMonth()) {
+			return `${format(start, "MMM d")} – ${format(end, "d, yyyy")}`;
+		}
+		return `${format(start, "MMM d")} – ${format(end, "MMM d, yyyy")}`;
+	}
+	return `${format(start, "MMM d, yyyy")} – ${format(end, "MMM d, yyyy")}`;
+}
+
+function buildPreviewText(
+	totalEvents: number,
+	organizationCount: number,
+	range: string,
+) {
+	const eventLabel = `${totalEvents} upcoming event${totalEvents === 1 ? "" : "s"}`;
+	const orgLabel = `${organizationCount} organization${organizationCount === 1 ? "" : "s"}`;
+	return `${eventLabel} across ${orgLabel} through ${range}`;
+}
+
+type SegmentGroup = {
+	segment: DigestSegmentValue;
+	organizations: Array<{
+		organization: {
+			id: string;
+			name: string;
+			slug: string | null;
+		};
+		events: Array<{
+			id: string;
+			title: string;
+			startAt: Date;
+			endAt: Date | null;
+			location: string | null;
+			url: string | null;
+		}>;
+	}>;
+};
+
+type ComposeInput = {
+	user: { id: string; email: string; name: string | null };
+	schedules: DigestScheduleRecord[];
+	now: Date;
+	limitPerSegment?: number;
+	maxPerOrganization?: number;
+};
+
+type ComposeResult = {
+	subject: string;
+	previewText: string | null;
+	html: string;
+	text: string;
+	anchorEventId: string;
+	segments: SegmentGroup[];
+	totalEvents: number;
+	organizationCount: number;
+	windowStart: Date;
+	windowEnd: Date;
+};
+
+async function ensureSchedules(): Promise<DigestScheduleRecord[]> {
+	const existing = await db.select().from(digestSchedule);
+	const existingSegments = new Set(existing.map((item) => item.segment));
+	const missing = DIGEST_SEGMENTS.filter(
+		(segment) => !existingSegments.has(segment),
+	);
+
+	if (missing.length === 0) {
+		return existing;
+	}
+
+	const now = new Date();
+	const defaults = missing.map(
+		(segment) =>
+			({
+				id: randomUUID(),
+				segment,
+				enabled: false,
+				cadenceHours: DEFAULT_DIGEST_CADENCE_HOURS,
+				lookaheadDays: DEFAULT_DIGEST_LOOKAHEAD_DAYS,
+				metadata: {},
+				createdAt: now,
+				updatedAt: now,
+			}) satisfies typeof digestSchedule.$inferInsert,
+	);
+
+	if (defaults.length) {
+		await db
+			.insert(digestSchedule)
+			.values(defaults)
+			.onConflictDoNothing({ target: digestSchedule.segment });
+	}
+
+	return await db.select().from(digestSchedule);
+}
+
+function scheduleIsDue(schedule: DigestScheduleRecord, now: Date): boolean {
+	if (!schedule.enabled) return false;
+	if (!schedule.lastSentAt) return true;
+	const next = new Date(
+		schedule.lastSentAt.getTime() + schedule.cadenceHours * 60 * 60 * 1000,
+	);
+	return next.getTime() <= now.getTime();
+}
+
+type SegmentQueryRow = {
+	eventId: string;
+	title: string;
+	startAt: Date;
+	endAt: Date | null;
+	location: string | null;
+	url: string | null;
+	organizationId: string;
+	organizationName: string;
+	organizationSlug: string | null;
+};
+
+async function fetchSegmentRows(
+	segment: DigestSegmentValue,
+	userId: string,
+	windowStart: Date,
+	windowEnd: Date,
+	limit: number,
+): Promise<SegmentQueryRow[]> {
+	const baseConditions = and(
+		eq(event.status, "approved"),
+		eq(event.isPublished, true),
+		gte(event.startAt, windowStart),
+		lte(event.startAt, windowEnd),
+	);
+
+	if (segment === "joined") {
+		return await db
+			.select({
+				eventId: event.id,
+				title: event.title,
+				startAt: event.startAt,
+				endAt: event.endAt,
+				location: event.location,
+				url: event.url,
+				organizationId: organization.id,
+				organizationName: organization.name,
+				organizationSlug: organization.slug,
+			})
+			.from(event)
+			.innerJoin(provider, eq(provider.id, event.provider))
+			.innerJoin(
+				organizationProvider,
+				eq(organizationProvider.providerId, provider.id),
+			)
+			.innerJoin(
+				organization,
+				eq(organization.id, organizationProvider.organizationId),
+			)
+			.innerJoin(
+				member,
+				and(
+					eq(member.organizationId, organization.id),
+					eq(member.userId, userId),
+				),
+			)
+			.where(baseConditions)
+			.orderBy(event.startAt, event.id)
+			.limit(limit);
+	}
+
+	const membership = alias(member, "digest_membership");
+	return await db
+		.select({
+			eventId: event.id,
+			title: event.title,
+			startAt: event.startAt,
+			endAt: event.endAt,
+			location: event.location,
+			url: event.url,
+			organizationId: organization.id,
+			organizationName: organization.name,
+			organizationSlug: organization.slug,
+		})
+		.from(event)
+		.innerJoin(provider, eq(provider.id, event.provider))
+		.innerJoin(
+			organizationProvider,
+			eq(organizationProvider.providerId, provider.id),
+		)
+		.innerJoin(
+			organization,
+			eq(organization.id, organizationProvider.organizationId),
+		)
+		.leftJoin(
+			membership,
+			and(
+				eq(membership.organizationId, organization.id),
+				eq(membership.userId, userId),
+			),
+		)
+		.where(and(baseConditions, isNull(membership.id)))
+		.orderBy(event.startAt, event.id)
+		.limit(limit);
+}
+
+function mapRowsToGroups(
+	segment: DigestSegmentValue,
+	rows: SegmentQueryRow[],
+	limitPerSegment: number,
+	maxPerOrganization: number,
+): SegmentGroup {
+	const organizationMap = new Map<
+		string,
+		{
+			organization: {
+				id: string;
+				name: string;
+				slug: string | null;
+			};
+			events: SegmentGroup["organizations"][number]["events"];
+		}
+	>();
+
+	for (const row of rows) {
+		const orgId = row.organizationId;
+		if (!organizationMap.has(orgId)) {
+			organizationMap.set(orgId, {
+				organization: {
+					id: row.organizationId,
+					name: row.organizationName,
+					slug: row.organizationSlug,
+				},
+				events: [],
+			});
+		}
+		const entry = organizationMap.get(orgId);
+		if (!entry) continue;
+		if (entry.events.length >= maxPerOrganization) continue;
+		entry.events.push({
+			id: row.eventId,
+			title: row.title,
+			startAt: row.startAt,
+			endAt: row.endAt,
+			location: row.location,
+			url: row.url,
+		});
+	}
+
+	const organizations = Array.from(organizationMap.values())
+		.map((item) => ({
+			organization: item.organization,
+			events: item.events.sort(
+				(a, b) => a.startAt.getTime() - b.startAt.getTime(),
+			),
+		}))
+		.filter((entry) => entry.events.length > 0)
+		.sort(
+			(a, b) => a.events[0]?.startAt.getTime() - b.events[0]?.startAt.getTime(),
+		);
+
+	if (Number.isFinite(limitPerSegment) && limitPerSegment >= 0) {
+		let eventCount = 0;
+		for (const entry of organizations) {
+			if (eventCount >= limitPerSegment) {
+				entry.events = [];
+				continue;
+			}
+			const remaining = limitPerSegment - eventCount;
+			if (entry.events.length > remaining) {
+				entry.events = entry.events.slice(0, remaining);
+				eventCount = limitPerSegment;
+			} else {
+				eventCount += entry.events.length;
+			}
+		}
+	}
+
+	const filtered = organizations.filter((entry) => entry.events.length > 0);
+	return { segment, organizations: filtered } satisfies SegmentGroup;
+}
+
+async function composeDigestEmail({
+	user,
+	schedules,
+	now,
+	limitPerSegment = MAX_EVENTS_PER_SEGMENT,
+	maxPerOrganization = MAX_EVENTS_PER_ORGANIZATION,
+}: ComposeInput): Promise<ComposeResult | null> {
+	const segments: SegmentGroup[] = [];
+	let totalEvents = 0;
+	let organizationCount = 0;
+	let earliestEvent: { id: string; startAt: Date } | null = null;
+	let latestEventDate: Date | null = null;
+
+	for (const schedule of schedules) {
+		const lookaheadDays =
+			schedule.lookaheadDays ?? DEFAULT_DIGEST_LOOKAHEAD_DAYS;
+		const windowEnd = new Date(
+			now.getTime() + lookaheadDays * 24 * 60 * 60 * 1000,
+		);
+		const queryLimit = Math.max(limitPerSegment * 3, limitPerSegment);
+		const rows = await fetchSegmentRows(
+			schedule.segment,
+			user.id,
+			now,
+			windowEnd,
+			queryLimit,
+		);
+		if (!rows.length) {
+			continue;
+		}
+		const group = mapRowsToGroups(
+			schedule.segment,
+			rows,
+			limitPerSegment,
+			maxPerOrganization,
+		);
+		if (!group.organizations.length) {
+			continue;
+		}
+		segments.push(group);
+		organizationCount += group.organizations.length;
+		for (const org of group.organizations) {
+			for (const eventItem of org.events) {
+				totalEvents += 1;
+				if (
+					!earliestEvent ||
+					eventItem.startAt.getTime() < earliestEvent.startAt.getTime()
+				) {
+					earliestEvent = {
+						id: eventItem.id,
+						startAt: eventItem.startAt,
+					};
+				}
+				if (
+					!latestEventDate ||
+					eventItem.startAt.getTime() > latestEventDate.getTime()
+				) {
+					latestEventDate = eventItem.startAt;
+				}
+			}
+		}
+	}
+
+	if (!segments.length || !earliestEvent) {
+		return null;
+	}
+
+	const windowStart = earliestEvent.startAt;
+	const windowEnd = latestEventDate ?? earliestEvent.startAt;
+	const rangeLabel = formatDateRange(windowStart, windowEnd);
+	const subject = `Upcoming events digest · ${rangeLabel}`;
+	const previewText = buildPreviewText(
+		totalEvents,
+		organizationCount,
+		rangeLabel,
+	);
+	const html = renderDigestHtml({ user, segments, rangeLabel, previewText });
+	const text = renderDigestText({ user, segments, rangeLabel, previewText });
+
+	return {
+		subject,
+		previewText,
+		html,
+		text,
+		anchorEventId: earliestEvent.id,
+		segments,
+		totalEvents,
+		organizationCount,
+		windowStart,
+		windowEnd,
+	} satisfies ComposeResult;
+}
+
+type RenderInput = {
+	user: { id: string; email: string; name: string | null };
+	segments: SegmentGroup[];
+	rangeLabel: string;
+	previewText: string | null;
+};
+
+function renderDigestHtml({ user, segments, rangeLabel }: RenderInput) {
+	const htmlParts: string[] = [];
+	htmlParts.push(
+		"<div style=\"font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; line-height: 1.6; color: #1f2933;\">",
+	);
+	const greetingName = user.name?.trim() ?? GREETING_FALLBACK;
+	htmlParts.push(`<p>Hi ${escapeHtml(greetingName)},</p>`);
+	htmlParts.push(
+		`<p>Here’s what’s coming up between <strong>${escapeHtml(rangeLabel)}</strong>.</p>`,
+	);
+	for (const segment of segments) {
+		const label = SEGMENT_LABELS[segment.segment];
+		htmlParts.push(
+			`<h2 style="margin-top: 24px; margin-bottom: 8px; font-size: 18px; font-weight: 600;">${escapeHtml(label.title)}</h2>`,
+		);
+		htmlParts.push(
+			`<p style="margin-top: 0; margin-bottom: 16px; color: #4b5563;">${escapeHtml(label.description)}</p>`,
+		);
+		for (const org of segment.organizations) {
+			htmlParts.push(
+				`<div style="margin-bottom: 16px; padding: 16px; border: 1px solid #e5e7eb; border-radius: 12px; background-color: #f9fafb;">`,
+			);
+			htmlParts.push(
+				`<h3 style="margin: 0 0 12px; font-size: 16px; font-weight: 600;">${escapeHtml(org.organization.name)}</h3>`,
+			);
+			htmlParts.push('<ul style="margin: 0; padding-left: 16px;">');
+			for (const eventItem of org.events) {
+				const eventUrl = safeUrl(eventItem.url);
+				const location = eventItem.location?.trim();
+				htmlParts.push('<li style="margin-bottom: 12px;">');
+				htmlParts.push(
+					`<div style="font-weight: 600; color: #111827;">${escapeHtml(eventItem.title)}</div>`,
+				);
+				htmlParts.push(
+					`<div style="color: #374151;">${escapeHtml(formatDisplayDate(eventItem.startAt))}</div>`,
+				);
+				if (location) {
+					htmlParts.push(
+						`<div style="color: #4b5563;">Location: ${escapeHtml(location)}</div>`,
+					);
+				}
+				if (eventUrl) {
+					htmlParts.push(
+						`<div><a href="${escapeHtml(eventUrl)}" style="color: #2563eb;">View details</a></div>`,
+					);
+				}
+				htmlParts.push("</li>");
+			}
+			htmlParts.push("</ul>");
+			htmlParts.push("</div>");
+		}
+	}
+	htmlParts.push(
+		'<p style="margin-top: 24px; color: #4b5563;">You’re receiving this digest because your workspace enabled upcoming event summaries. Visit your dashboard to adjust notification preferences.</p>',
+	);
+	htmlParts.push("</div>");
+	return htmlParts.join("");
+}
+
+function renderDigestText({ user, segments, rangeLabel }: RenderInput) {
+	const textParts: string[] = [];
+	const greetingName = user.name?.trim() ?? GREETING_FALLBACK;
+	textParts.push(`Hi ${greetingName},`);
+	textParts.push(`Here’s what’s coming up between ${rangeLabel}.`);
+	for (const segment of segments) {
+		const label = SEGMENT_LABELS[segment.segment];
+		textParts.push("");
+		textParts.push(label.title.toUpperCase());
+		textParts.push(label.description);
+		for (const org of segment.organizations) {
+			textParts.push("");
+			textParts.push(`- ${org.organization.name}`);
+			for (const eventItem of org.events) {
+				textParts.push(
+					`  • ${eventItem.title} (${formatDisplayDate(eventItem.startAt)})`,
+				);
+				if (eventItem.location?.trim()) {
+					textParts.push(`    Location: ${eventItem.location.trim()}`);
+				}
+				if (eventItem.url?.trim()) {
+					textParts.push(`    Details: ${eventItem.url.trim()}`);
+				}
+			}
+		}
+	}
+	textParts.push("");
+	textParts.push(
+		"You’re receiving this digest because your workspace enabled upcoming event summaries.",
+	);
+	return textParts.join("\n");
+}
+
+export function parseDigestMetadata(value: unknown): DigestMetadata | null {
+	if (!value || typeof value !== "object") {
+		return null;
+	}
+	const envelope = (value as Record<string, unknown>).digest ?? value;
+	if (!envelope || typeof envelope !== "object") {
+		return null;
+	}
+	const record = envelope as Record<string, unknown>;
+	const content = record.content;
+	if (!content || typeof content !== "object") {
+		return null;
+	}
+	const subject = (content as Record<string, unknown>).subject;
+	const html = (content as Record<string, unknown>).html;
+	const text = (content as Record<string, unknown>).text;
+	const previewText = (content as Record<string, unknown>).previewText;
+	if (
+		typeof subject !== "string" ||
+		typeof html !== "string" ||
+		typeof text !== "string"
+	) {
+		return null;
+	}
+	return {
+		version: 1,
+		userId: typeof record.userId === "string" ? record.userId : undefined,
+		summary: record.summary as DigestMetadata["summary"],
+		segments: record.segments as DigestMetadata["segments"],
+		content: {
+			subject,
+			html,
+			text,
+			previewText:
+				typeof previewText === "string" && previewText.trim().length
+					? previewText
+					: null,
+		},
+	} satisfies DigestMetadata;
+}
+
+type ScheduleDigestOptions = {
+	now?: Date;
+	limitPerSegment?: number;
+	maxPerOrganization?: number;
+	limitUsers?: number;
+};
+
+type ScheduleDigestResult = {
+	queued: number;
+	segmentsProcessed: DigestSegmentValue[];
+	segmentsWithEvents: DigestSegmentValue[];
+	recipientsConsidered: number;
+};
+
+async function hasPendingDigest(recipientEmail: string, now: Date) {
+	const existing = await db
+		.select({ id: eventEmailDelivery.id })
+		.from(eventEmailDelivery)
+		.where(
+			and(
+				eq(eventEmailDelivery.recipientEmail, recipientEmail),
+				eq(eventEmailDelivery.type, "digest"),
+				inArray(eventEmailDelivery.status, ["pending", "sending"]),
+				gte(
+					eventEmailDelivery.scheduledAt,
+					new Date(now.getTime() - 6 * 60 * 60 * 1000),
+				),
+			),
+		)
+		.limit(1);
+	return existing.length > 0;
+}
+
+export async function scheduleDigestDeliveries({
+	now = new Date(),
+	limitPerSegment,
+	maxPerOrganization,
+	limitUsers,
+}: ScheduleDigestOptions = {}): Promise<ScheduleDigestResult> {
+	const schedules = await ensureSchedules();
+	const dueSchedules = schedules.filter((schedule) =>
+		scheduleIsDue(schedule, now),
+	);
+	if (!dueSchedules.length) {
+		return {
+			queued: 0,
+			segmentsProcessed: [],
+			segmentsWithEvents: [],
+			recipientsConsidered: 0,
+		};
+	}
+	let userQuery = db
+		.select({
+			id: user.id,
+			email: user.email,
+			name: user.name,
+			banned: user.banned,
+		})
+		.from(user)
+		.orderBy(user.createdAt);
+	if (limitUsers && limitUsers > 0) {
+		userQuery = userQuery.limit(limitUsers);
+	}
+	const usersToProcess = await userQuery;
+	let queued = 0;
+	let recipientsConsidered = 0;
+	const segmentsWithEvents = new Set<DigestSegmentValue>();
+	for (const recipient of usersToProcess) {
+		if (!recipient.email) continue;
+		if (recipient.banned) continue;
+		if (await hasPendingDigest(recipient.email, now)) {
+			continue;
+		}
+		const composeResult = await composeDigestEmail({
+			user: { id: recipient.id, email: recipient.email, name: recipient.name },
+			schedules: dueSchedules,
+			now,
+			limitPerSegment,
+			maxPerOrganization,
+		});
+		recipientsConsidered += 1;
+		if (!composeResult) {
+			continue;
+		}
+		for (const segment of composeResult.segments) {
+			segmentsWithEvents.add(segment.segment);
+		}
+		const metadata: DigestMetadata = {
+			version: 1,
+			userId: recipient.id,
+			summary: {
+				totalEvents: composeResult.totalEvents,
+				organizationCount: composeResult.organizationCount,
+				windowStart: composeResult.windowStart.toISOString(),
+				windowEnd: composeResult.windowEnd.toISOString(),
+				generatedAt: now.toISOString(),
+			},
+			segments: composeResult.segments.map((segment) => ({
+				segment: segment.segment,
+				organizations: segment.organizations.map((org) => ({
+					id: org.organization.id,
+					name: org.organization.name,
+					slug: org.organization.slug,
+					events: org.events.map((eventItem) => ({
+						id: eventItem.id,
+						title: eventItem.title,
+						startAt: eventItem.startAt.toISOString(),
+						endAt: eventItem.endAt?.toISOString() ?? null,
+						location: eventItem.location,
+						url: eventItem.url,
+					})),
+				})),
+			})),
+			content: {
+				subject: composeResult.subject,
+				previewText: composeResult.previewText,
+				html: composeResult.html,
+				text: composeResult.text,
+			},
+		} satisfies DigestMetadata;
+		const inserted = await queueEmailDelivery({
+			eventId: composeResult.anchorEventId,
+			recipientEmail: recipient.email,
+			recipientName: recipient.name ?? null,
+			type: "digest",
+			metadata: { digest: metadata },
+			subject: composeResult.subject,
+			scheduledAt: now,
+		});
+		if (inserted) {
+			queued += 1;
+		}
+	}
+	if (dueSchedules.length) {
+		const summaryMetadata = {
+			lastQueuedRecipients: queued,
+			lastAttemptAt: now.toISOString(),
+			segmentsWithEvents: Array.from(segmentsWithEvents),
+		} as Record<string, unknown>;
+		await db
+			.update(digestSchedule)
+			.set({
+				lastSentAt: now,
+				metadata: summaryMetadata,
+				updatedAt: now,
+			})
+			.where(
+				inArray(
+					digestSchedule.id,
+					dueSchedules.map((schedule) => schedule.id),
+				),
+			);
+	}
+	return {
+		queued,
+		segmentsProcessed: dueSchedules.map((schedule) => schedule.segment),
+		segmentsWithEvents: Array.from(segmentsWithEvents),
+		recipientsConsidered,
+	} satisfies ScheduleDigestResult;
+}

--- a/apps/server/src/lib/query-keys/digests.ts
+++ b/apps/server/src/lib/query-keys/digests.ts
@@ -1,0 +1,4 @@
+export const digestKeys = {
+	all: ["adminDigests"] as const,
+	schedules: () => [...digestKeys.all, "schedules"] as const,
+} as const;

--- a/apps/server/src/routers/admin-digests.ts
+++ b/apps/server/src/routers/admin-digests.ts
@@ -1,0 +1,147 @@
+import { randomUUID } from "node:crypto";
+
+import { TRPCError } from "@trpc/server";
+import { asc, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { db } from "@/db";
+import { digestSchedule } from "@/db/schema/app";
+import {
+	DEFAULT_DIGEST_CADENCE_HOURS,
+	DEFAULT_DIGEST_LOOKAHEAD_DAYS,
+	DIGEST_SEGMENTS,
+	type DigestSegmentValue,
+} from "@/lib/mailer/digest";
+import { adminProcedure, router } from "@/lib/trpc";
+
+const segmentSchema = z.enum(
+	DIGEST_SEGMENTS as [DigestSegmentValue, ...DigestSegmentValue[]],
+);
+
+const updateSchema = z.object({
+	segment: segmentSchema,
+	enabled: z.boolean(),
+	cadenceHours: z
+		.number()
+		.int()
+		.min(6, "Cadence must be at least 6 hours")
+		.max(24 * 24, "Cadence cannot exceed 24 days"),
+	lookaheadDays: z
+		.number()
+		.int()
+		.min(1, "Lookahead must be at least 1 day")
+		.max(90, "Lookahead cannot exceed 90 days"),
+});
+
+type ScheduleRecord = typeof digestSchedule.$inferSelect;
+
+type ScheduleEntity = {
+	id: string;
+	segment: DigestSegmentValue;
+	enabled: boolean;
+	cadenceHours: number;
+	lookaheadDays: number;
+	lastSentAt: string | null;
+	metadata: Record<string, unknown>;
+	createdAt: string;
+	updatedAt: string;
+};
+
+async function ensureSchedule(
+	segment: DigestSegmentValue,
+): Promise<ScheduleRecord> {
+	const existing = await db
+		.select()
+		.from(digestSchedule)
+		.where(eq(digestSchedule.segment, segment))
+		.limit(1);
+	const row = existing.at(0);
+	if (row) {
+		return row;
+	}
+	const now = new Date();
+	const [created] = await db
+		.insert(digestSchedule)
+		.values({
+			id: randomUUID(),
+			segment,
+			enabled: false,
+			cadenceHours: DEFAULT_DIGEST_CADENCE_HOURS,
+			lookaheadDays: DEFAULT_DIGEST_LOOKAHEAD_DAYS,
+			metadata: {},
+			createdAt: now,
+			updatedAt: now,
+		})
+		.returning();
+	if (!created) {
+		throw new TRPCError({
+			code: "INTERNAL_SERVER_ERROR",
+			message: "Unable to create digest schedule",
+		});
+	}
+	return created;
+}
+
+function mapSchedule(record: ScheduleRecord): ScheduleEntity {
+	return {
+		id: record.id,
+		segment: record.segment,
+		enabled: record.enabled,
+		cadenceHours: record.cadenceHours,
+		lookaheadDays: record.lookaheadDays,
+		lastSentAt: record.lastSentAt?.toISOString() ?? null,
+		metadata: (record.metadata ?? {}) as Record<string, unknown>,
+		createdAt: record.createdAt?.toISOString?.() ?? new Date().toISOString(),
+		updatedAt: record.updatedAt?.toISOString?.() ?? new Date().toISOString(),
+	} satisfies ScheduleEntity;
+}
+
+async function loadAllSchedules(): Promise<ScheduleRecord[]> {
+	const records = await db
+		.select()
+		.from(digestSchedule)
+		.orderBy(asc(digestSchedule.segment));
+	const foundSegments = new Set(records.map((item) => item.segment));
+	if (foundSegments.size === DIGEST_SEGMENTS.length) {
+		return records;
+	}
+	const created: ScheduleRecord[] = [...records];
+	for (const segment of DIGEST_SEGMENTS) {
+		if (!foundSegments.has(segment)) {
+			created.push(await ensureSchedule(segment));
+		}
+	}
+	return created.sort(
+		(a, b) =>
+			DIGEST_SEGMENTS.indexOf(a.segment) - DIGEST_SEGMENTS.indexOf(b.segment),
+	);
+}
+
+export const adminDigestsRouter = router({
+	listSchedules: adminProcedure.query(async () => {
+		const rows = await loadAllSchedules();
+		return rows.map(mapSchedule);
+	}),
+	updateSchedule: adminProcedure
+		.input(updateSchema)
+		.mutation(async ({ input }) => {
+			await ensureSchedule(input.segment);
+			const [updated] = await db
+				.update(digestSchedule)
+				.set({
+					enabled: input.enabled,
+					cadenceHours: input.cadenceHours,
+					lookaheadDays: input.lookaheadDays,
+					updatedAt: new Date(),
+				})
+				.where(eq(digestSchedule.segment, input.segment))
+				.returning();
+			if (!updated) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Schedule not found",
+				});
+			}
+			return mapSchedule(updated);
+		}),
+});

--- a/apps/server/src/routers/index.ts
+++ b/apps/server/src/routers/index.ts
@@ -1,4 +1,5 @@
 import { protectedProcedure, publicProcedure, router } from "../lib/trpc";
+import { adminDigestsRouter } from "./admin-digests";
 import { adminFlagsRouter } from "./admin-flags";
 import { adminLogsRouter } from "./admin-logs";
 import { adminUsersRouter } from "./admin-users";
@@ -22,5 +23,6 @@ export const appRouter = router({
 	adminUsers: adminUsersRouter,
 	adminFlags: adminFlagsRouter,
 	adminLogs: adminLogsRouter,
+	adminDigests: adminDigestsRouter,
 });
 export type AppRouter = typeof appRouter;


### PR DESCRIPTION
## Summary
- add a mailer digest composer with scheduling logic and persistence for digest deliveries
- extend the cron email handler to enqueue digests behind a feature flag and record metadata
- expose digest cadence controls in the admin console with supporting schema, migration, and query keys

## Testing
- bun run check *(fails: existing lint rules flag tailwind @apply/@theme usage and other legacy issues)*

------
https://chatgpt.com/codex/tasks/task_b_68e3dbc4fdd48327bb1eca27adc6e974