### PR TITLE
feat(worker): add ingest pipeline with metrics

### DIFF
--- a/apps/worker/src/ingest/confidence.ts
+++ b/apps/worker/src/ingest/confidence.ts
@@ -1,0 +1,79 @@
+import type { EventSqlInsert } from "../utils/mailparser";
+import type {
+	ConfidenceResult,
+	DuplicateCheckResult,
+	IngestContext,
+	SpamCheckResult,
+} from "./types";
+
+function scoreBase(extraction: EventSqlInsert): number {
+	let score = 0.35;
+
+	if (extraction.title.trim().length > 8) score += 0.1;
+	if (extraction.description && extraction.description.length > 40)
+		score += 0.05;
+	if (extraction.location && extraction.location.length > 3) score += 0.1;
+	if (extraction.url) score += 0.1;
+	if (extraction.end_at) score += 0.05;
+	if (extraction.is_published) score += 0.05;
+
+	// Encourage explicit metadata that often comes from high quality sources
+	if (extraction.metadata?.organizer) score += 0.05;
+	if (extraction.metadata?.source === "email") score += 0.05;
+
+	return score;
+}
+
+function clampScore(value: number): number {
+	if (Number.isNaN(value)) return 0;
+	return Math.min(1, Math.max(0, value));
+}
+
+function resolveLevel(score: number): "low" | "medium" | "high" {
+	if (score >= 0.8) return "high";
+	if (score >= 0.6) return "medium";
+	return "low";
+}
+
+export function scoreConfidence(
+	extraction: EventSqlInsert,
+	spam: SpamCheckResult,
+	duplicate: DuplicateCheckResult,
+	context: IngestContext,
+): ConfidenceResult {
+	const reasons: string[] = [];
+	let score = scoreBase(extraction);
+
+	if (spam.flagged) {
+		score -= spam.scorePenalty;
+		reasons.push("spam_penalty");
+	}
+
+	if (duplicate.duplicate) {
+		score -= duplicate.scorePenalty;
+		reasons.push("duplicate_penalty");
+	}
+
+	if (context.provider.trusted) {
+		score += 0.05;
+	}
+
+	if (context.message.internalDate) {
+		score += 0.05;
+	}
+
+	score = clampScore(score);
+	const level = resolveLevel(score);
+	const autoApprove = level === "high" && !spam.flagged && !duplicate.duplicate;
+
+	if (!autoApprove) {
+		reasons.push("auto_approval_withheld");
+	}
+
+	return {
+		score,
+		level,
+		reasons,
+		autoApprove,
+	} satisfies ConfidenceResult;
+}

--- a/apps/worker/src/ingest/duplicate-detector.ts
+++ b/apps/worker/src/ingest/duplicate-detector.ts
@@ -1,0 +1,117 @@
+import { sql } from "bun";
+
+import type { EventSqlInsert } from "../utils/mailparser";
+import type { DuplicateCheckResult, IngestContext } from "./types";
+
+const DUPLICATE_LOOKBACK_MINUTES = 60 * 24 * 7; // one week
+
+function createLookbackWindow(startAt: string | null | undefined): Date | null {
+	if (!startAt) return null;
+	const date = new Date(startAt);
+	if (Number.isNaN(date.getTime())) return null;
+	const lookback = new Date(
+		date.getTime() - DUPLICATE_LOOKBACK_MINUTES * 60_000,
+	);
+	return lookback;
+}
+
+async function findDuplicateByExternalId(
+	extraction: EventSqlInsert,
+): Promise<string | null> {
+	if (!extraction.external_id) return null;
+	const [row] = await sql<{ id: string }[]>`
+                SELECT id
+                FROM event
+                WHERE provider_id = ${extraction.provider_id}
+                  AND external_id = ${extraction.external_id}
+                LIMIT 1
+        `;
+	return row?.id ?? null;
+}
+
+async function findDuplicateByTitleAndTime(
+	extraction: EventSqlInsert,
+): Promise<string | null> {
+	const lookback = createLookbackWindow(extraction.start_at);
+	if (!lookback) return null;
+
+	const [row] = await sql<{ id: string }[]>`
+                SELECT id
+                FROM event
+                WHERE provider_id = ${extraction.provider_id}
+                  AND lower(title) = lower(${extraction.title})
+                  AND start_at BETWEEN ${lookback.toISOString()}::timestamptz AND ${
+										extraction.start_at
+									}::timestamptz
+                ORDER BY start_at DESC
+                LIMIT 1
+        `;
+	return row?.id ?? null;
+}
+
+async function findDuplicateByUrl(
+	extraction: EventSqlInsert,
+): Promise<string | null> {
+	if (!extraction.url) return null;
+	const [row] = await sql<{ id: string }[]>`
+                SELECT id
+                FROM event
+                WHERE provider_id = ${extraction.provider_id}
+                  AND metadata ->> 'source_url' = ${extraction.url}
+                LIMIT 1
+        `;
+	return row?.id ?? null;
+}
+
+export async function detectDuplicate(
+	extraction: EventSqlInsert,
+	context: IngestContext,
+): Promise<DuplicateCheckResult> {
+	const reasons: string[] = [];
+	let existing: string | null = null;
+
+	existing = await findDuplicateByExternalId(extraction);
+	if (existing) {
+		reasons.push("external_id_match");
+	}
+
+	if (!existing) {
+		existing = await findDuplicateByTitleAndTime(extraction);
+		if (existing) {
+			reasons.push("title_time_window_match");
+		}
+	}
+
+	if (!existing) {
+		existing = await findDuplicateByUrl(extraction);
+		if (existing) {
+			reasons.push("source_url_match");
+		}
+	}
+
+	const duplicate = Boolean(existing);
+
+	if (duplicate) {
+		context.metrics.incrementCounter(
+			"worker_ingest_duplicate_detected_total",
+			1,
+			{
+				provider_id: context.provider.id,
+				mailbox: context.message.mailbox,
+			},
+		);
+		context.logger.info("Duplicate detected prior to insert", {
+			mailbox: context.message.mailbox,
+			uid: context.message.uid,
+			reasons,
+			existingEventId: existing,
+		});
+	}
+
+	return {
+		duplicate,
+		reasons,
+		existingEventId: existing,
+		scorePenalty: duplicate ? 0.3 : 0,
+	} satisfies DuplicateCheckResult;
+}

--- a/apps/worker/src/ingest/index.ts
+++ b/apps/worker/src/ingest/index.ts
@@ -1,0 +1,105 @@
+import type { EventSqlInsert } from "../utils/mailparser";
+import { scoreConfidence } from "./confidence";
+import { detectDuplicate } from "./duplicate-detector";
+import { runSpamFilter } from "./spam-filter";
+import type {
+	IngestDecision,
+	IngestMetadataSnapshot,
+	IngestPipelineInput,
+} from "./types";
+
+function buildExtractionSnapshot(
+	extraction: EventSqlInsert,
+): Record<string, unknown> {
+	return {
+		title: extraction.title,
+		description: extraction.description ?? null,
+		location: extraction.location ?? null,
+		url: extraction.url ?? null,
+		start_at: extraction.start_at,
+		end_at: extraction.end_at ?? null,
+		is_all_day: extraction.is_all_day ?? false,
+		is_published: extraction.is_published ?? false,
+		priority: extraction.priority ?? 3,
+		flag_id: extraction.flag_id ?? null,
+		external_id: extraction.external_id ?? null,
+		metadata: extraction.metadata ?? {},
+	} satisfies Record<string, unknown>;
+}
+
+export async function runIngestPipeline({
+	context,
+	extraction,
+}: IngestPipelineInput): Promise<IngestDecision> {
+	const spam = runSpamFilter(extraction, context);
+	const duplicate = await detectDuplicate(extraction, context);
+	const confidence = scoreConfidence(extraction, spam, duplicate, context);
+
+	let proceed = true;
+	let skipReason: string | undefined;
+
+	if (duplicate.duplicate) {
+		proceed = false;
+		skipReason = "duplicate";
+	}
+
+	const baseStatus = extraction.status ?? "pending";
+	let status = baseStatus;
+	let autoApproved = status === "approved";
+	let autoApprovalReason: string | null = null;
+
+	if (context.provider.trusted) {
+		if (confidence.autoApprove) {
+			status = "approved";
+			autoApproved = true;
+			autoApprovalReason = "trusted_provider_high_confidence";
+		} else {
+			status = "pending";
+			autoApproved = false;
+			autoApprovalReason = "confidence_low";
+		}
+	} else {
+		if (status === "approved" && !confidence.autoApprove) {
+			status = "pending";
+			autoApproved = false;
+			autoApprovalReason = "confidence_low";
+		}
+	}
+
+	if (spam.flagged && autoApproved) {
+		// Safety net: do not allow auto approval on spam even if trusted.
+		status = "pending";
+		autoApproved = false;
+		autoApprovalReason = "spam_detected";
+	}
+
+	const snapshot: IngestMetadataSnapshot = {
+		spam,
+		duplicate,
+		confidence,
+		extraction: buildExtractionSnapshot(extraction),
+	};
+
+	const metadataPatch: Record<string, unknown> = {
+		ingest_pipeline: {
+			...snapshot,
+			decision: {
+				status,
+				auto_approved: autoApproved,
+				reason: autoApprovalReason,
+				skipped: !proceed,
+				skip_reason: skipReason ?? null,
+			},
+		},
+	};
+
+	return {
+		proceed,
+		status,
+		autoApproved,
+		autoApprovalReason,
+		skipReason,
+		duplicateEventId: duplicate.existingEventId ?? null,
+		metadataPatch,
+	} satisfies IngestDecision;
+}

--- a/apps/worker/src/ingest/spam-filter.ts
+++ b/apps/worker/src/ingest/spam-filter.ts
@@ -1,0 +1,92 @@
+import type { EventSqlInsert } from "../utils/mailparser";
+import type { IngestContext, SpamCheckResult } from "./types";
+
+const spamKeywords = [
+	"unsubscribe",
+	"lottery",
+	"sweepstakes",
+	"crypto",
+	"bet now",
+	"guaranteed winner",
+	"adult",
+	"viagra",
+	"pills",
+	"free money",
+];
+
+const suspiciousPhrases = [
+	"not an event",
+	"special promotion",
+	"buy now",
+	"limited time offer",
+	"sponsored content",
+];
+
+const suspiciousDomains = ["example-spam.com", "spammy.biz", "clickme.net"];
+
+function containsSpamKeyword(value: string | null | undefined): boolean {
+	if (!value) return false;
+	const normalized = value.toLowerCase();
+	return spamKeywords.some((keyword) => normalized.includes(keyword));
+}
+
+function containsSuspiciousPhrase(value: string | null | undefined): boolean {
+	if (!value) return false;
+	const normalized = value.toLowerCase();
+	return suspiciousPhrases.some((phrase) => normalized.includes(phrase));
+}
+
+function hasSuspiciousDomain(url: string | null | undefined): boolean {
+	if (!url) return false;
+	try {
+		const parsed = new URL(url);
+		return suspiciousDomains.some((domain) => parsed.hostname.includes(domain));
+	} catch {
+		return false;
+	}
+}
+
+export function runSpamFilter(
+	extraction: EventSqlInsert,
+	context: IngestContext,
+): SpamCheckResult {
+	const reasons: string[] = [];
+
+	if (containsSpamKeyword(extraction.title)) {
+		reasons.push("title_contains_spam_keyword");
+	}
+
+	if (containsSpamKeyword(extraction.description)) {
+		reasons.push("description_contains_spam_keyword");
+	}
+
+	if (containsSuspiciousPhrase(extraction.description)) {
+		reasons.push("description_contains_suspicious_phrase");
+	}
+
+	if (hasSuspiciousDomain(extraction.url ?? null)) {
+		reasons.push("suspicious_url_domain");
+	}
+
+	const flagged = reasons.length > 0;
+	if (flagged) {
+		context.metrics.incrementCounter("worker_ingest_spam_detected_total", 1, {
+			provider_id: context.provider.id,
+			mailbox: context.message.mailbox,
+		});
+	}
+
+	if (flagged) {
+		context.logger.debug("Spam filter flagged extraction", {
+			mailbox: context.message.mailbox,
+			uid: context.message.uid,
+			reasons,
+		});
+	}
+
+	return {
+		flagged,
+		reasons,
+		scorePenalty: flagged ? 0.4 : 0,
+	} satisfies SpamCheckResult;
+}

--- a/apps/worker/src/ingest/types.ts
+++ b/apps/worker/src/ingest/types.ts
@@ -1,0 +1,61 @@
+import type { WorkerLogger, WorkerMetrics } from "../services/log";
+import type { ProviderRecord } from "../types/provider";
+import type { EventSqlInsert } from "../utils/mailparser";
+
+export interface MessageIngestContext {
+	uid: number;
+	mailbox: string;
+	internalDate?: Date | null;
+	messageId?: string | null;
+}
+
+export interface IngestContext {
+	provider: ProviderRecord;
+	logger: WorkerLogger;
+	metrics: WorkerMetrics;
+	message: MessageIngestContext;
+}
+
+export interface SpamCheckResult {
+	flagged: boolean;
+	reasons: string[];
+	scorePenalty: number;
+}
+
+export interface DuplicateCheckResult {
+	duplicate: boolean;
+	reasons: string[];
+	scorePenalty: number;
+	existingEventId?: string | null;
+}
+
+export type ConfidenceLevel = "low" | "medium" | "high";
+
+export interface ConfidenceResult {
+	score: number;
+	level: ConfidenceLevel;
+	reasons: string[];
+	autoApprove: boolean;
+}
+
+export interface IngestMetadataSnapshot {
+	spam: SpamCheckResult;
+	duplicate: DuplicateCheckResult;
+	confidence: ConfidenceResult;
+	extraction: Record<string, unknown>;
+}
+
+export interface IngestDecision {
+	proceed: boolean;
+	status: "pending" | "approved" | "rejected";
+	autoApproved: boolean;
+	autoApprovalReason: string | null;
+	skipReason?: string;
+	duplicateEventId?: string | null;
+	metadataPatch: Record<string, unknown>;
+}
+
+export interface IngestPipelineInput {
+	context: IngestContext;
+	extraction: EventSqlInsert;
+}


### PR DESCRIPTION
## Summary
- add a pre-insert ingest pipeline for spam filtering, duplicate detection, and confidence scoring
- persist extraction snapshots and confidence metadata to event records for admin QA context
- emit StatsD-style metrics with alert thresholds for extraction and insert failures alongside the worker log sink

## Testing
- bun run check *(fails: existing Biome config/version warnings and unrelated lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_68e3e3a89124832784580345caa24e9f