### PR TITLE
fix: await calendar route params

### DIFF
--- a/apps/server/src/app/(api)/api/calendar/[org].ics/route.ts
+++ b/apps/server/src/app/(api)/api/calendar/[org].ics/route.ts
@@ -7,6 +7,10 @@ import { buildICS } from "@/lib/calendar-links";
 
 export const runtime = "nodejs";
 
+type RouteHandlerContext = {
+	params?: Promise<Record<string, string | string[] | undefined>>;
+};
+
 function escapeText(value: string): string {
 	return value
 		.replace(/\\/g, "\\\\")
@@ -71,9 +75,11 @@ function buildCalendarFeed(
 
 export async function GET(
 	_req: Request,
-	context: { params: { org: string } },
+	context: RouteHandlerContext,
 ): Promise<Response> {
-	const slug = context.params.org;
+	const params = await context.params;
+	const orgParam = params?.org;
+	const slug = Array.isArray(orgParam) ? orgParam.at(0) : orgParam;
 	if (!slug || slug.trim().length === 0) {
 		return new Response("Not found", { status: 404 });
 	}


### PR DESCRIPTION
## Summary
- add a route handler context type that mirrors Next.js app route expectations
- await the async params value and normalize the `org` slug before querying

## Testing
- bun run --filter server build *(fails: Next.js cannot download hosted Geist font in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_b_68e4fd7a04cc83279e53232baf07fc1f