### PR TITLE
fix(server): update calendar route handler context type

### DIFF
--- a/apps/server/src/app/(api)/api/calendar/[org].ics/route.ts
+++ b/apps/server/src/app/(api)/api/calendar/[org].ics/route.ts
@@ -7,10 +7,6 @@ import { buildICS } from "@/lib/calendar-links";
 
 export const runtime = "nodejs";
 
-type RouteHandlerContext = {
-	params?: Promise<Record<string, string | string[] | undefined>>;
-};
-
 function escapeText(value: string): string {
 	return value
 		.replace(/\\/g, "\\\\")
@@ -75,9 +71,8 @@ function buildCalendarFeed(
 
 export async function GET(
 	_req: Request,
-	context: RouteHandlerContext,
+	{ params }: { params: { [key: string]: string | string[] | undefined } },
 ): Promise<Response> {
-	const params = await context.params;
 	const orgParam = params?.org;
 	const slug = Array.isArray(orgParam) ? orgParam.at(0) : orgParam;
 	if (!slug || slug.trim().length === 0) {


### PR DESCRIPTION
## Summary
- remove the custom RouteHandlerContext type that awaited params in the calendar feed route
- inline a Next.js-compatible params typing for the GET handler to keep the existing slug parsing logic

## Testing
- bun run build *(fails: Next.js could not download https://fonts.gstatic.com/s/geist/v4/gyByhwUxId8gMEwSGFWNOITddY4.woff2)*

------
https://chatgpt.com/codex/tasks/task_b_68e500c863e88327b1e4f553feee6ae3