### PR TITLE
chore(server): run migrations on startup

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -55,4 +55,8 @@ COPY --from=builder /app/apps/server/.next ./apps/server/.next
 COPY --from=builder /app/apps/server/src/db ./apps/server/src/db
 
 EXPOSE 3000
+COPY --from=builder /app/apps/server/docker-entrypoint.sh ./docker-entrypoint.sh
+RUN chmod +x ./docker-entrypoint.sh
+
+ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["bun", "run", "--filter", "server", "start"]

--- a/apps/server/docker-entrypoint.sh
+++ b/apps/server/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -euo pipefail
+
+if [ "${SKIP_DB_MIGRATE:-}" = "" ]; then
+  echo "Running database migrations..."
+  bun run db:migrate
+else
+  echo "Skipping database migrations because SKIP_DB_MIGRATE is set."
+fi
+
+echo "Starting server..."
+exec "$@"


### PR DESCRIPTION
## Summary
- add a Docker entrypoint script that runs `bun run db:migrate` before starting the server
- update the server image to ship the entrypoint and use it for container startup

## Testing
- bun run build *(fails in the container environment after the Next.js build step completes type checking)*

------
https://chatgpt.com/codex/tasks/task_b_68e615a8adcc8327819b1df1234d0ec7